### PR TITLE
Add note about disabling iTerm2 keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ or with specifying a different program to launch
 ❯ t-rec /bin/sh
 ```
 
+If you are using **iTerm2**, Make sure you disable the default keybinding of `CTRL-D` which eliminates terminal. (How: Go to `Preference` -> `Keys` -> `Key Bindings` -> Add key -> {Shortcut: ^D, Action: Ignore}).
+
 ### Hidden Gems
 
 You can record not only the terminal but also every other window. There 2 ways to do so:

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
         "Frame cache dir: {:?}",
         tempdir.lock().expect("Cannot lock tempdir resource").path()
     );
-    println!("Press Ctrl+D to end recording");
+    println!("Press Ctrl+D to end recording (If you are using iTerm2, make sure you disable the default Ctrl-D keybinding which eliminates terminal.)");
 
     interact
         .join()


### PR DESCRIPTION
If you are using iTerm2, its default keybinds of Ctrl-D eliminates Terminal. Therefore, we can't use t-rec-rs while it's active.