### PR TITLE
feat(overwriting): #8 avoid overwriting existing final gif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CHANGELOG.md follows now a [new format](https://keepachangelog.com/en/1.0.0/)
 - feature to check for `convert` on launch [issue/6] / [pull/7]
-- feature to avoid overwriting existing final gif [issue/8] / [pull/X]
+- feature to avoid overwriting existing final gif [issue/8] / [pull/9]
 
 [issue/6]: https://github.com/sassman/t-rec-rs/issues/6
 [issue/8]: https://github.com/sassman/t-rec-rs/issues/8
 [pull/7]: https://github.com/sassman/t-rec-rs/pull/7
+[pull/9]: https://github.com/sassman/t-rec-rs/pull/9
 
 ## [0.1.1] - 2020-10-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 🎯 [Unreleased]
+### Added
+- CHANGELOG.md follows now a [new format](https://keepachangelog.com/en/1.0.0/)
+- feature to check for `convert` on launch [issue/6] / [pull/7]
+- feature to avoid overwriting existing final gif [issue/8] / [pull/X]
+
+[issue/6]: https://github.com/sassman/t-rec-rs/issues/6
+[issue/8]: https://github.com/sassman/t-rec-rs/issues/8
+[pull/7]: https://github.com/sassman/t-rec-rs/pull/7
+
+## [0.1.1] - 2020-10-11
+### Fixed
+- Segmentation fault on listing the windows `t-rec -l` [issue/4]
+
+## [0.1.0] - 2020-10-10
+### Added
+- Basic recoding functionality with 4 FPS
+- Generating a gif out of n frames of a recording
+- CI pipeline as GitHub Actions workflow
+
+[issue/4]: https://github.com/sassman/t-rec-rs/issues/4

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ fn check_for_imagemagick() -> Result<Output> {
 ///
 /// generating the final gif with help of convert
 fn generate_gif_with_convert(time_codes: &[u128], tempdir: &TempDir) -> Result<()> {
-    let target = "t-rec.gif";
+    let target = target_file();
     println!(
         "\n🎉 🚀 Generating {:?} out of {} frames!",
         target,
@@ -187,6 +187,19 @@ fn generate_gif_with_convert(time_codes: &[u128], tempdir: &TempDir) -> Result<(
         .context("Cannot start 'convert' to generate the final gif")?;
 
     Ok(())
+}
+
+///
+/// returns a new filename that does not yet exists.
+/// like `t-rec.gif` or `t-rec_1.gif`
+fn target_file() -> String {
+    let mut suffix = "".to_string();
+    let mut i = 0;
+    while std::path::Path::new(format!("t-rec{}.gif", suffix).as_str()).exists() {
+        i += 1;
+        suffix = format!("_{}", i).to_string();
+    }
+    format!("t-rec{}.gif", suffix)
 }
 
 /// TODO implement a image native gif creation


### PR DESCRIPTION
 - check if file `t-rec.gif` exisits in `$CWD` and generates suffixes until it does not more exists
 - like `t-rec_2.gif`