### PR TITLE
First attempt to make a snap of t-rec

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: t-rec
+base: core20 
+adopt-info: t-rec
+summary: Terminal Recorder - t-rec
+description: |
+  Blazingly fast terminal recorder that generates animated gif images for the web written in rust.
+
+grade: stable
+confinement: classic
+
+parts:
+  t-rec:
+    plugin: rust
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags)"
+    override-build: |
+      snapcraftctl build
+      cd $SNAPCRAFT_PART_INSTALL/usr/bin
+      ln -s ./convert-im6.q16 ./convert
+    build-packages: 
+      - libx11-dev
+    stage-packages: 
+      - imagemagick
+
+apps:
+  t-rec:
+    command: bin/t-rec


### PR DESCRIPTION
Hi. I work on snapcraft for Canonical. Thought I'd take a stab at making a t-rec snap. This seems to work for me on Ubuntu. 

![t-rec](https://user-images.githubusercontent.com/1841272/103311939-87e99b80-4a13-11eb-8642-ca348e2c5a17.gif)

It's a `classic` (unconfined) snap, because it needs to be able to launch any arbitrary binary on the end-user system. If you're happy with this, I can either register and get this published in the snap store, and maintain it, or I can guide you to do that. Your choice. :D