### PR TITLE
Fix/issue 30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +235,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "env_logger"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
 name = "image"
 version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
+name = "log"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +366,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -541,6 +584,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "regex"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,8 +637,10 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "core-graphics",
+ "env_logger",
  "gif",
  "image",
+ "log",
  "objc-foundation",
  "objc_id",
  "tempfile",
@@ -599,12 +662,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -657,6 +738,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-wsapoll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ image = "0.23.12"
 anyhow = "1.0.35"
 tempfile = "3.1.0"
 gif = "0.11"
+log = "0.4.11"
+env_logger = "0.8.2"
 #image-convert = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/linux/x11_api.rs
+++ b/src/linux/x11_api.rs
@@ -370,22 +370,22 @@ mod test {
         let api = X11Api::new()?;
         let windows = api.get_visible_windows()?;
         assert!(!windows.is_empty(), "Window list should never be empty!");
-        for win in windows {
-            let name = api.get_window_name(&win)?;
-            assert!(name.is_some(), "A window should always have a name");
-        }
-
         let window = api.get_active_window()?;
         assert!(
             windows.contains(&window),
             "Active window was not found in visible list"
         );
+        for win in windows {
+            let name = api.get_window_name(&win)?;
+            assert!(name.is_some(), "A window should always have a name");
+        }
+
         let name = api.get_window_name(&window)?;
         if let Some(name) = name {
             assert!(!name.is_empty());
             println!("Active window: {:?}", name);
         } else {
-            assert!(false, "this should not have happened");
+            panic!("this should not have happened");
         }
 
         Ok(())

--- a/src/linux/x11_api.rs
+++ b/src/linux/x11_api.rs
@@ -262,7 +262,13 @@ impl PlatformApi for X11Api {
                 u32::MAX,
             )?
             .reply()?;
-        let window = prop.value32().unwrap().next().unwrap();
+        let window = prop
+            .value32()
+            .context(
+                "Window Manager does not have an active window property (NET_ACTIVE_WINDOW) set.",
+            )?
+            .next()
+            .unwrap();
 
         Ok(window as WindowId)
     }

--- a/src/linux/x11_api.rs
+++ b/src/linux/x11_api.rs
@@ -3,6 +3,7 @@ use crate::{ImageOnHeap, PlatformApi, Result, WindowId, WindowList};
 use anyhow::Context;
 use image::flat::{SampleLayout, View};
 use image::{Bgra, ColorType, FlatSamples, GenericImageView};
+use log::debug;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 use x11rb::rust_connection::{DefaultStream, RustConnection};
@@ -93,7 +94,14 @@ impl X11Api {
                 let attr = conn.get_window_attributes(window)?.reply()?;
                 if let MapState::Viewable = attr.map_state {
                     result.push(window as WindowId);
+                } else {
+                    debug!(
+                        "Window {} with {} x {} is unmapped",
+                        window_id, width, height
+                    );
                 }
+            } else {
+                debug!("Window {} with {} x {}", window_id, width, height);
             }
             let mut sub_windows = self.get_all_sub_windows(&window_id)?;
             result.append(&mut sub_windows);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ macro_rules! prof {
 }
 
 fn main() -> Result<()> {
+    env_logger::init();
+
     let args = launch();
     if args.is_present("list-windows") {
         return ls_win();


### PR DESCRIPTION
This PR fixes #30 and also makes sure the window names are printed correctly

Fail with a proper error message:
![image](https://user-images.githubusercontent.com/329682/103386904-30295e00-4b01-11eb-9e00-00dac64b79a3.png)

Showing now window titles for `t-rec -l`:
![image](https://user-images.githubusercontent.com/329682/103387080-205e4980-4b02-11eb-88df-2d2c9aa4f8aa.png)
