### PR TITLE
reduce crate size from 4.8MB to to 34kB by adjusting the Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ readme = "README.md"
 keywords = ["recorder", "image", "terminal", "gif", "commandline"]
 categories = ["multimedia::images", "command-line-utilities"]
 repository = "https://github.com/sassman/t-rec-rs"
-exclude = [".github/*", ".gitignore"]
 links = "X11"
 build = "build.rs"
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "build.rs"]
 
 [badges]
 github-actions = { repository = "sassman/t-rec-rs", branch = "main", workflow = "Build" }


### PR DESCRIPTION
This commit is more of a suggestion and the start of a conversation
as it removes all files not required to build from the packaged crate.

Please let me know if keeping tests is preferred in this case, or if
there are any other files that should rather remain included.

This was achieved with `cargo diet -r`, here is the output indicating the savings:

```
┌───────────────────────────────────────────┬─────────────┐
│ File                                      │ Size (Byte) │
├───────────────────────────────────────────┼─────────────┤
│ .github/FUNDING.yml                       │          63 │
│ .gitignore                                │         313 │
│ .github/ISSUE_TEMPLATE/feature_request.md │         601 │
│ snap/snapcraft.yaml                       │         626 │
│ .github/ISSUE_TEMPLATE/bug_report.md      │         736 │
│ .brew/t-rec.rb                            │         898 │
│ .brew/t-rec-not-working-on-github.rb      │        1327 │
│ resources/list.c                          │        2249 │
│ .github/workflows/build.yml               │        3409 │
│ .github/workflows/release.yml             │        5686 │
│ docs/demo-mint.gif                        │       33928 │
│ docs/demo-ubuntu-i3wm.gif                 │       36705 │
│ docs/demo-ubuntu.gif                      │       38521 │
│ docs/demo-shadow.gif                      │      163219 │
│ docs/demo.gif                             │     1158944 │
│ docs/demo-vscode.gif                      │     1177428 │
│ docs/demo-chrome.gif                      │     1857443 │
│ tests/frames/t-rec-frame-000004876.tga    │     2678162 │
│ tests/frames/t-rec-frame-000004607.tga    │     2678162 │
│ tests/frames/t-rec-frame-000004334.tga    │     2678162 │
│ tests/frames/t-rec-frame-000004064.tga    │     2678162 │
│ tests/frames/t-rec-frame-000003784.tga    │     2678162 │
│ tests/frames/t-rec-frame-000003516.tga    │     2678162 │
│ tests/frames/t-rec-frame-000003237.tga    │     2678162 │
│ tests/frames/t-rec-frame-000002960.tga    │     2678162 │
│ tests/frames/t-rec-frame-000002685.tga    │     2678162 │
│ tests/frames/t-rec-frame-000002403.tga    │     2678162 │
│ tests/frames/t-rec-frame-000002131.tga    │     2678162 │
│ tests/frames/t-rec-frame-000001848.tga    │     2678162 │
│ tests/frames/t-rec-frame-000001576.tga    │     2678162 │
│ tests/frames/t-rec-frame-000001306.tga    │     2678162 │
│ tests/frames/t-rec-frame-000001036.tga    │     2678162 │
│ tests/frames/t-rec-frame-000000775.tga    │     2678162 │
│ tests/frames/t-rec-frame-000000512.tga    │     2678162 │
│ tests/frames/t-rec-frame-000000251.tga    │     2678162 │
│ resources/t-rec-frame-000000251.tga       │     4757778 │
└───────────────────────────────────────────┴─────────────┘
Saved 100% or 57.4 MB in 36 files (of 57.5 MB and 53 files in entire crate)
```