### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,10 +580,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "t-rec"
@@ -581,6 +616,9 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "tempfile",
+ "uuid",
+ "winapi",
+ "winrt",
  "x11rb",
 ]
 
@@ -623,6 +661,21 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "vec_map"
@@ -672,6 +725,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winmd"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/winrt-rs?rev=a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3#a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha1",
+ "winmd_macros",
+]
+
+[[package]]
+name = "winmd_macros"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/winrt-rs?rev=a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3#a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "winrt"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/winrt-rs?rev=a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3#a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3"
+dependencies = [
+ "winrt_macros",
+]
+
+[[package]]
+name = "winrt_macros"
+version = "0.1.0"
+source = "git+https://github.com/microsoft/winrt-rs?rev=a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3#a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "winmd",
+]
 
 [[package]]
 name = "x11rb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,13 @@ core-foundation-sys = "0.8"
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = "0.7"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.8", features = [ "std", "winuser", "d3d11", "d2d1", "dxgi", "d3dcommon", "impl-default", "dwmapi", "wincon" ] }
+winrt = { git = "https://github.com/microsoft/winrt-rs", rev = "a036b8e61c0859ba9b72e9fe5c913cd4439c6ed3" }
+uuid = { version = "0.8", features = ["v4"] }
+
+# [target.'cfg(target_os = "windows")'.build-dependencies]
+# winrt = { git = "https://github.com/microsoft/winrt-rs", rev = "bacab1e162987fe5974f74425419d11f0c686ccf" }
+
 [features]
 test_against_real_display = []

--- a/src/decor_effect.rs
+++ b/src/decor_effect.rs
@@ -20,7 +20,8 @@ pub fn apply_shadow_effect(time_codes: &[u128], tempdir: &TempDir, bg_color: Str
         time_codes,
         tempdir,
         Box::new(move |file| {
-            Command::new("convert")
+            Command::new("magick")
+                .arg("convert")
                 .arg(file.to_str().unwrap())
                 .arg("(")
                 .args(&["+clone", "-background", "black", "-shadow", "100x20+0+0"])
@@ -53,7 +54,8 @@ pub fn apply_big_sur_corner_effect(time_codes: &[u128], tempdir: &TempDir) -> Re
         time_codes,
         tempdir,
         Box::new(move |file| {
-            Command::new("convert")
+            Command::new("magick")
+                .arg("convert")
                 .arg(file.to_str().unwrap())
                 .arg("-trim")
                 .arg("(")

--- a/src/gif_gen.rs
+++ b/src/gif_gen.rs
@@ -13,7 +13,8 @@ use tempfile::TempDir;
 pub fn generate_gif_with_convert(time_codes: &[u128], tempdir: &TempDir) -> Result<()> {
     let target = target_file();
     println!("🎉 🚀 Generating {}", target);
-    let mut cmd = Command::new("convert");
+    let mut cmd = Command::new("magick");
+    cmd.arg("convert");
     cmd.arg("-loop").arg("0");
     let mut delay = 0;
     for tc in time_codes.iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,10 +273,11 @@ fn current_win_id() -> Result<(WindowId, Option<String>)> {
 /// checks for imagemagick
 /// and suggests the installation command if there are issues
 fn check_for_imagemagick() -> Result<Output> {
-    Command::new("convert")
+    Command::new("magick")
+        .arg("convert")
         .arg("--version")
         .output()
-        .context("There is an issue with 'convert', make sure you have it installed: `brew install imagemagick`")
+        .context("There is an issue with 'magick', make sure you have it installed: `brew install imagemagick`")
 }
 
 ///

--- a/src/win/capture.rs
+++ b/src/win/capture.rs
@@ -1,0 +1,86 @@
+use crate::windows::graphics::capture::GraphicsCaptureItem;
+use winapi::shared::windef::{HMONITOR, HWND};
+use winrt::{ComInterface, Guid, TryInto};
+
+#[repr(C)]
+pub struct abi_IGraphicsCaptureItemInterop {
+    __base: [usize; 3],
+    create_for_window: extern "system" fn(
+        *const *const abi_IGraphicsCaptureItemInterop,
+        HWND,
+        &Guid,
+        *mut winrt::RawPtr,
+    ) -> winrt::ErrorCode,
+    create_for_monitor: extern "system" fn(
+        *const *const abi_IGraphicsCaptureItemInterop,
+        HMONITOR,
+        &Guid,
+        *mut winrt::RawPtr,
+    ) -> winrt::ErrorCode,
+}
+
+unsafe impl winrt::ComInterface for GraphicsCaptureItemInterop {
+    type VTable = abi_IGraphicsCaptureItemInterop;
+    const IID: winrt::Guid =
+        winrt::Guid::from_values(908650523, 15532, 19552, [183, 244, 35, 206, 14, 12, 51, 86]);
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct GraphicsCaptureItemInterop {
+    ptr: winrt::ComPtr<GraphicsCaptureItemInterop>,
+}
+
+impl GraphicsCaptureItemInterop {
+    // pub fn create_for_monitor(&self, monitor: HMONITOR) -> winrt::Result<GraphicsCaptureItem> {
+    //     let this = self.ptr.abi();
+    //     if this.is_null() {
+    //         panic!("`this` was null");
+    //     }
+    //     unsafe {
+    //         let mut result: GraphicsCaptureItem = std::mem::zeroed();
+
+    //         ((*(*(this))).create_for_monitor)(
+    //             this,
+    //             monitor,
+    //             &GraphicsCaptureItem::IID,
+    //             &mut result as *mut _ as _,
+    //         )
+    //         .ok()?;
+    //         Ok(result)
+    //     }
+    // }
+
+    pub fn create_for_window(&self, window: HWND) -> winrt::Result<GraphicsCaptureItem> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+        unsafe {
+            let mut result: GraphicsCaptureItem = std::mem::zeroed();
+
+            ((*(*(this))).create_for_window)(
+                this,
+                window,
+                &GraphicsCaptureItem::IID,
+                &mut result as *mut _ as _,
+            )
+            .ok()?;
+            Ok(result)
+        }
+    }
+}
+
+// pub fn create_capture_item_for_monitor(monitor: HMONITOR) -> winrt::Result<GraphicsCaptureItem> {
+//     let factory = winrt::activation::factory::<GraphicsCaptureItem, winrt::IActivationFactory>()?;
+//     let interop: GraphicsCaptureItemInterop = factory.try_into()?;
+//     let item = interop.create_for_monitor(monitor)?;
+//     Ok(item)
+// }
+
+pub fn create_capture_item_for_window(window: HWND) -> winrt::Result<GraphicsCaptureItem> {
+    let factory = winrt::activation::factory::<GraphicsCaptureItem, winrt::IActivationFactory>()?;
+    let interop: GraphicsCaptureItemInterop = factory.try_into()?;
+    let item = interop.create_for_window(window)?;
+    Ok(item)
+}

--- a/src/win/d3d.rs
+++ b/src/win/d3d.rs
@@ -1,0 +1,476 @@
+use crate::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+use winapi::{
+    shared::{
+        dxgi::{IDXGIDeviceVtbl, IDXGISurfaceVtbl},
+        winerror::DXGI_ERROR_UNSUPPORTED,
+    },
+    um::d3d11::{
+        D3D11CreateDevice, ID3D11DeviceContextVtbl, ID3D11DeviceVtbl, ID3D11Resource,
+        ID3D11Texture2DVtbl, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAP, D3D11_MAPPED_SUBRESOURCE,
+        D3D11_SDK_VERSION, D3D11_SUBRESOURCE_DATA, D3D11_TEXTURE2D_DESC,
+    },
+};
+use winrt::{Guid, RuntimeType, TryInto};
+
+#[repr(C)]
+pub struct abi_IDirect3DDxgiInterfaceAccess {
+    __base: [usize; 3],
+    get_interface: extern "system" fn(
+        *const *const abi_IDirect3DDxgiInterfaceAccess,
+        &Guid,
+        *mut winrt::RawPtr,
+    ) -> winrt::ErrorCode,
+}
+
+unsafe impl winrt::ComInterface for Direct3DDxgiInterfaceAccess {
+    type VTable = abi_IDirect3DDxgiInterfaceAccess;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        2847133714,
+        15858,
+        20195,
+        [184, 209, 134, 149, 244, 87, 211, 193],
+    );
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct Direct3DDxgiInterfaceAccess {
+    ptr: winrt::ComPtr<Direct3DDxgiInterfaceAccess>,
+}
+
+impl Direct3DDxgiInterfaceAccess {
+    pub fn get_interface<Into: winrt::ComInterface>(&self) -> winrt::Result<Into> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+        unsafe {
+            let mut result: Into = std::mem::zeroed();
+
+            ((*(*(this))).get_interface)(this, &Into::IID, &mut result as *mut _ as _).ok()?;
+            Ok(result)
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct D3D11Texture2D {
+    ptr: winrt::ComPtr<D3D11Texture2D>,
+}
+
+unsafe impl winrt::ComInterface for D3D11Texture2D {
+    type VTable = ID3D11Texture2DVtbl;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        1863690994,
+        53768,
+        20105,
+        [154, 180, 72, 149, 53, 211, 79, 156],
+    );
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct D3D11Device {
+    ptr: winrt::ComPtr<D3D11Device>,
+}
+
+unsafe impl winrt::ComInterface for D3D11Device {
+    type VTable = ID3D11DeviceVtbl;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        3681512923,
+        44151,
+        20104,
+        [130, 83, 129, 157, 249, 187, 241, 64],
+    );
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct D3D11DeviceContext {
+    ptr: winrt::ComPtr<D3D11DeviceContext>,
+}
+
+unsafe impl winrt::ComInterface for D3D11DeviceContext {
+    type VTable = ID3D11DeviceContextVtbl;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        3233786220,
+        57481,
+        17659,
+        [142, 175, 38, 248, 121, 97, 144, 218],
+    );
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct DXGISurface {
+    ptr: winrt::ComPtr<DXGISurface>,
+}
+
+unsafe impl winrt::ComInterface for DXGISurface {
+    type VTable = IDXGISurfaceVtbl;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        3405559148,
+        27331,
+        18569,
+        [191, 71, 158, 35, 187, 210, 96, 236],
+    );
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone)]
+pub struct DXGIDevice {
+    ptr: winrt::ComPtr<DXGIDevice>,
+}
+
+unsafe impl winrt::ComInterface for DXGIDevice {
+    type VTable = IDXGIDeviceVtbl;
+    const IID: winrt::Guid = winrt::Guid::from_values(
+        1424783354,
+        4983,
+        17638,
+        [140, 50, 136, 253, 95, 68, 200, 76],
+    );
+}
+
+pub trait D3D11Resource {
+    fn get_d3d_resource(&self) -> *mut ID3D11Resource;
+}
+
+impl D3D11Resource for D3D11Texture2D {
+    fn get_d3d_resource(&self) -> *mut ID3D11Resource {
+        let this = self.ptr.abi();
+        this as *mut _
+    }
+}
+
+#[link(name = "d3d11")]
+extern "stdcall" {
+    fn CreateDirect3D11DeviceFromDXGIDevice(
+        device: winrt::RawComPtr<DXGIDevice>,
+        graphics_device: *mut <IDirect3DDevice as RuntimeType>::Abi,
+    ) -> winrt::ErrorCode;
+}
+
+#[link(name = "d3d11")]
+extern "stdcall" {
+    fn CreateDirect3D11SurfaceFromDXGISurface(
+        surface: winrt::RawComPtr<DXGISurface>,
+        graphics_surface: *mut <IDirect3DSurface as RuntimeType>::Abi,
+    ) -> winrt::ErrorCode;
+}
+
+#[allow(dead_code)]
+#[repr(u32)]
+pub enum D3DDriverType {
+    Unknown = 0,
+    Hardware = 1,
+    Reference = 2,
+    Null = 3,
+    Software = 4,
+    Warp = 5,
+}
+
+impl D3D11Device {
+    pub fn from_direct3d_device(device: &IDirect3DDevice) -> winrt::Result<Self> {
+        let access: Direct3DDxgiInterfaceAccess = device.try_into()?;
+        access.get_interface()
+    }
+
+    pub fn new_of_type(driver_type: D3DDriverType) -> winrt::Result<Self> {
+        let flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+        let device = unsafe {
+            let mut device = winrt::IUnknown::default();
+            winrt::ErrorCode(D3D11CreateDevice(
+                std::ptr::null_mut(),
+                driver_type as u32,
+                std::ptr::null_mut(),
+                flags,
+                std::ptr::null(),
+                0,
+                D3D11_SDK_VERSION,
+                device.set_abi() as *mut *mut _,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ))
+            .ok()?;
+            std::mem::transmute(device)
+        };
+        Ok(Self { ptr: device })
+    }
+
+    pub fn new() -> winrt::Result<Self> {
+        let result = Self::new_of_type(D3DDriverType::Hardware);
+        match result {
+            Ok(device) => Ok(device),
+            Err(error) => {
+                if error.code().0 == DXGI_ERROR_UNSUPPORTED {
+                    Self::new_of_type(D3DDriverType::Warp)
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
+    pub fn to_direct3d_device(&self) -> winrt::Result<IDirect3DDevice> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        unsafe {
+            let dxgi_device: DXGIDevice = self.try_into()?;
+            let mut result: IDirect3DDevice = std::mem::zeroed();
+            CreateDirect3D11DeviceFromDXGIDevice(dxgi_device.ptr.abi(), result.set_abi()).ok()?;
+            Ok(result)
+        }
+    }
+
+    pub fn create_texture_2d(
+        &self,
+        desc: &D3D11_TEXTURE2D_DESC,
+        initial_data: Option<&D3D11_SUBRESOURCE_DATA>,
+    ) -> winrt::Result<D3D11Texture2D> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        unsafe {
+            let mut result: D3D11Texture2D = std::mem::zeroed();
+
+            let initial_data = match initial_data {
+                Some(data) => data,
+                None => std::ptr::null(),
+            };
+
+            winrt::ErrorCode(((*(*(this))).CreateTexture2D)(
+                this as *mut _,
+                desc,
+                initial_data,
+                &mut result as *mut _ as _,
+            ))
+            .ok()?;
+            Ok(result)
+        }
+    }
+
+    pub fn get_immediate_context(&self) -> D3D11DeviceContext {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        unsafe {
+            let mut result: D3D11DeviceContext = std::mem::zeroed();
+
+            ((*(*(this))).GetImmediateContext)(this as *mut _, &mut result as *mut _ as _);
+            result
+        }
+    }
+}
+
+impl D3D11DeviceContext {
+    pub fn map(
+        &self,
+        resource: &dyn D3D11Resource,
+        subresource: u32,
+        map_type: D3D11_MAP,
+        map_flags: u32,
+        mapped_resource: &mut D3D11_MAPPED_SUBRESOURCE,
+    ) -> winrt::Result<()> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        let resource = resource.get_d3d_resource();
+        if resource.is_null() {
+            panic!("'resource' was null");
+        }
+
+        unsafe {
+            winrt::ErrorCode(((*(*(this))).Map)(
+                this as *mut _,
+                resource,
+                subresource,
+                map_type,
+                map_flags,
+                mapped_resource as *mut _,
+            ))
+            .ok()?;
+        };
+
+        Ok(())
+    }
+
+    pub fn unmap(&self, resource: &dyn D3D11Resource, subresource: u32) {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        let resource = resource.get_d3d_resource();
+        if resource.is_null() {
+            panic!("'resource' was null");
+        }
+
+        unsafe {
+            ((*(*(this))).Unmap)(this as *mut _, resource, subresource);
+        };
+    }
+
+    pub fn copy_resource(&self, dest: &dyn D3D11Resource, src: &dyn D3D11Resource) {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        let dest = dest.get_d3d_resource();
+        if dest.is_null() {
+            panic!("'dest' was null");
+        }
+
+        let src = src.get_d3d_resource();
+        if src.is_null() {
+            panic!("'src' was null");
+        }
+
+        unsafe {
+            ((*(*(this))).CopyResource)(this as *mut _, dest, src);
+        };
+    }
+}
+
+impl D3D11Texture2D {
+    pub fn from_direct3d_surface(surface: &IDirect3DSurface) -> winrt::Result<Self> {
+        let access: Direct3DDxgiInterfaceAccess = surface.try_into()?;
+        access.get_interface()
+    }
+
+    pub fn to_direct3d_surface(&self) -> winrt::Result<IDirect3DSurface> {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        unsafe {
+            let dxgi_surface: DXGISurface = self.try_into()?;
+            let mut result: IDirect3DSurface = std::mem::zeroed();
+            CreateDirect3D11SurfaceFromDXGISurface(dxgi_surface.ptr.abi(), result.set_abi())
+                .ok()?;
+            Ok(result)
+        }
+    }
+
+    pub fn get_desc(&self) -> D3D11_TEXTURE2D_DESC {
+        let this = self.ptr.abi();
+        if this.is_null() {
+            panic!("`this` was null");
+        }
+
+        unsafe {
+            let mut result = D3D11_TEXTURE2D_DESC::default();
+            ((*(*(this))).GetDesc)(this as *mut _, &mut result as *mut _);
+            result
+        }
+    }
+}
+
+#[test]
+fn test_d3d_device() -> winrt::Result<()> {
+    use crate::windows::graphics::capture::Direct3D11CaptureFramePool;
+    use crate::windows::graphics::directx::DirectXPixelFormat;
+    use crate::windows::graphics::SizeInt32;
+
+    let d3d_device = D3D11Device::new()?;
+    let device = d3d_device.to_direct3d_device()?;
+
+    // The frame pool will create d3d textures
+    let _frame_pool = Direct3D11CaptureFramePool::create_free_threaded(
+        &device,
+        DirectXPixelFormat::B8G8R8A8UIntNormalized,
+        1,
+        SizeInt32 {
+            width: 100,
+            height: 100,
+        },
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_d3d_texture_2d() -> winrt::Result<()> {
+    use winapi::{
+        shared::{dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM, dxgitype::DXGI_SAMPLE_DESC},
+        um::d3d11::{
+            D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_SUBRESOURCE_DATA, D3D11_TEXTURE2D_DESC,
+            D3D11_USAGE_STAGING,
+        },
+    };
+
+    let d3d_device = D3D11Device::new()?;
+    let d3d_context = d3d_device.get_immediate_context();
+
+    // Create and fill our texture with red
+    let width = 200u32;
+    let height = 200u32;
+    let desc = D3D11_TEXTURE2D_DESC {
+        Width: width,
+        Height: height,
+        MipLevels: 1,
+        ArraySize: 1,
+        Format: DXGI_FORMAT_B8G8R8A8_UNORM,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Usage: D3D11_USAGE_STAGING,
+        BindFlags: 0,
+        CPUAccessFlags: D3D11_CPU_ACCESS_READ,
+        MiscFlags: 0,
+    };
+    let mut data = Vec::new();
+    for _ in 0..width * height {
+        data.push(0u8);
+        data.push(0u8);
+        data.push(255u8);
+        data.push(255u8);
+    }
+    let data: &[u8] = &data;
+    let subresource_data = D3D11_SUBRESOURCE_DATA {
+        pSysMem: data.as_ptr() as *const _,
+        SysMemPitch: width * 4,
+        SysMemSlicePitch: 0,
+    };
+    let texture = d3d_device.create_texture_2d(&desc, Some(&subresource_data))?;
+
+    // Lock and read the texture, verifying it has red pixels
+    let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+    d3d_context.map(&texture, 0, D3D11_MAP_READ, 0, &mut mapped)?;
+
+    // Get a slice of bytes
+    let slice: &[u8] = unsafe {
+        std::slice::from_raw_parts(
+            mapped.pData as *const _,
+            (height * mapped.RowPitch) as usize,
+        )
+    };
+
+    // Find the center of the texture
+    let center_x = width / 2;
+    let center_y = height / 2;
+    let offset = ((center_y * mapped.RowPitch) + (center_x * 4)) as usize;
+
+    // Test for red
+    assert_eq!(slice[offset], 0);
+    assert_eq!(slice[offset + 1], 0);
+    assert_eq!(slice[offset + 2], 255);
+    assert_eq!(slice[offset + 3], 255);
+
+    d3d_context.unmap(&texture, 0);
+
+    Ok(())
+}

--- a/src/win/encoder.rs
+++ b/src/win/encoder.rs
@@ -1,0 +1,144 @@
+use super::d3d::{D3D11Device, D3D11Texture2D};
+use crate::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+// use std::path::Path;
+
+use winapi::{
+    shared::dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM,
+    um::d3d11::{
+        D3D11_CPU_ACCESS_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_READ, D3D11_USAGE_STAGING,
+    },
+};
+
+
+// pub fn save_d3d_surface<P>(
+//     device: &IDirect3DDevice,
+//     surface: &IDirect3DSurface,
+//     path: P,
+// ) -> winrt::Result<()>
+// where
+//     P: AsRef<Path>,
+// {
+//     let d3d_device = D3D11Device::from_direct3d_device(device)?;
+//     let d3d_context = d3d_device.get_immediate_context();
+//     let d3d_texture = D3D11Texture2D::from_direct3d_surface(surface)?;
+
+//     // Make sure the surface is a pixel format we support
+//     let desc = d3d_texture.get_desc();
+//     let width = desc.Width as u32;
+//     let height = desc.Height as u32;
+//     let bytes_per_pixel = match desc.Format {
+//         DXGI_FORMAT_B8G8R8A8_UNORM => 4,
+//         _ => panic!("Unsupported format! {:?}", desc.Format),
+//     };
+
+//     // TODO: If the texture isn't marked for staging, make a copy
+//     let d3d_texture = if desc.Usage == D3D11_USAGE_STAGING {
+//         if (desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ) == D3D11_CPU_ACCESS_READ {
+//             d3d_texture
+//         } else {
+//             panic!("CPU read access required!");
+//         }
+//     } else {
+//         panic!("Unsupported buffer type! Must be a staging buffer!");
+//     };
+
+//     // Map the texture
+//     let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+//     d3d_context.map(&d3d_texture, 0, D3D11_MAP_READ, 0, &mut mapped)?;
+
+//     // Get a slice of bytes
+//     let slice: &[u8] = unsafe {
+//         std::slice::from_raw_parts(
+//             mapped.pData as *const _,
+//             (height * mapped.RowPitch) as usize,
+//         )
+//     };
+
+//     // Make a copy of the data
+//     let mut data = vec![0u8; ((width * height) * bytes_per_pixel) as usize];
+//     for row in 0..height {
+//         let data_begin = (row * (width * bytes_per_pixel)) as usize;
+//         let data_end = ((row + 1) * (width * bytes_per_pixel)) as usize;
+//         let slice_begin = (row * mapped.RowPitch) as usize;
+//         let slice_end = slice_begin + (width * bytes_per_pixel) as usize;
+//         data[data_begin..data_end].copy_from_slice(&slice[slice_begin..slice_end]);
+//     }
+
+//     // Unmap the texture
+//     d3d_context.unmap(&d3d_texture, 0);
+
+//     // Save the bits
+//     let image: image::ImageBuffer<image::Bgra<u8>, _> =
+//         image::ImageBuffer::from_raw(width, height, data).unwrap();
+//     // The image crate doesn't seem to support saving bgra8 :(
+//     let dynamic_image = image::DynamicImage::ImageBgra8(image);
+//     let dynamic_image = dynamic_image.to_rgba();
+//     dynamic_image.save(path).unwrap();
+
+//     Ok(())
+// }
+
+pub fn encode_d3d_surface(
+    device: &IDirect3DDevice,
+    surface: &IDirect3DSurface,
+) -> winrt::Result<image::FlatSamples<Vec<u8>>>
+{
+    let d3d_device = D3D11Device::from_direct3d_device(device)?;
+    let d3d_context = d3d_device.get_immediate_context();
+    let d3d_texture = D3D11Texture2D::from_direct3d_surface(surface)?;
+
+    // Make sure the surface is a pixel format we support
+    let desc = d3d_texture.get_desc();
+    let width = desc.Width as u32;
+    let height = desc.Height as u32;
+    let bytes_per_pixel = match desc.Format {
+        DXGI_FORMAT_B8G8R8A8_UNORM => 4,
+        _ => panic!("Unsupported format! {:?}", desc.Format),
+    };
+
+    // TODO: If the texture isn't marked for staging, make a copy
+    let d3d_texture = if desc.Usage == D3D11_USAGE_STAGING {
+        if (desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ) == D3D11_CPU_ACCESS_READ {
+            d3d_texture
+        } else {
+            panic!("CPU read access required!");
+        }
+    } else {
+        panic!("Unsupported buffer type! Must be a staging buffer!");
+    };
+
+    // Map the texture
+    let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+    d3d_context.map(&d3d_texture, 0, D3D11_MAP_READ, 0, &mut mapped)?;
+
+    // Get a slice of bytes
+    let slice: &[u8] = unsafe {
+        std::slice::from_raw_parts(
+            mapped.pData as *const _,
+            (height * mapped.RowPitch) as usize,
+        )
+    };
+
+    // Make a copy of the data
+    let mut data = vec![0u8; ((width * height) * bytes_per_pixel) as usize];
+    for row in 0..height {
+        let data_begin = (row * (width * bytes_per_pixel)) as usize;
+        let data_end = ((row + 1) * (width * bytes_per_pixel)) as usize;
+        let slice_begin = (row * mapped.RowPitch) as usize;
+        let slice_end = slice_begin + (width * bytes_per_pixel) as usize;
+        data[data_begin..data_end].copy_from_slice(&slice[slice_begin..slice_end]);
+    }
+
+    // Unmap the texture
+    d3d_context.unmap(&d3d_texture, 0);
+
+    // Save the bits
+    let image: image::ImageBuffer<image::Bgra<u8>, _> =
+        image::ImageBuffer::from_raw(width, height, data).unwrap();
+    // // The image crate doesn't seem to support saving bgra8 :(
+    // let dynamic_image = image::DynamicImage::ImageBgra8(image);
+    // let dynamic_image = dynamic_image.to_rgba();
+    // dynamic_image.save(path).unwrap();
+
+    Ok(image.into_flat_samples())
+}

--- a/src/win/encoder.rs
+++ b/src/win/encoder.rs
@@ -1,5 +1,5 @@
 use super::d3d::{D3D11Device, D3D11Texture2D};
-use crate::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+use crate::win::windows::graphics::directx::direct3d11::IDirect3DSurface;
 // use std::path::Path;
 
 use winapi::{
@@ -9,81 +9,10 @@ use winapi::{
     },
 };
 
-
-// pub fn save_d3d_surface<P>(
-//     device: &IDirect3DDevice,
-//     surface: &IDirect3DSurface,
-//     path: P,
-// ) -> winrt::Result<()>
-// where
-//     P: AsRef<Path>,
-// {
-//     let d3d_device = D3D11Device::from_direct3d_device(device)?;
-//     let d3d_context = d3d_device.get_immediate_context();
-//     let d3d_texture = D3D11Texture2D::from_direct3d_surface(surface)?;
-
-//     // Make sure the surface is a pixel format we support
-//     let desc = d3d_texture.get_desc();
-//     let width = desc.Width as u32;
-//     let height = desc.Height as u32;
-//     let bytes_per_pixel = match desc.Format {
-//         DXGI_FORMAT_B8G8R8A8_UNORM => 4,
-//         _ => panic!("Unsupported format! {:?}", desc.Format),
-//     };
-
-//     // TODO: If the texture isn't marked for staging, make a copy
-//     let d3d_texture = if desc.Usage == D3D11_USAGE_STAGING {
-//         if (desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ) == D3D11_CPU_ACCESS_READ {
-//             d3d_texture
-//         } else {
-//             panic!("CPU read access required!");
-//         }
-//     } else {
-//         panic!("Unsupported buffer type! Must be a staging buffer!");
-//     };
-
-//     // Map the texture
-//     let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
-//     d3d_context.map(&d3d_texture, 0, D3D11_MAP_READ, 0, &mut mapped)?;
-
-//     // Get a slice of bytes
-//     let slice: &[u8] = unsafe {
-//         std::slice::from_raw_parts(
-//             mapped.pData as *const _,
-//             (height * mapped.RowPitch) as usize,
-//         )
-//     };
-
-//     // Make a copy of the data
-//     let mut data = vec![0u8; ((width * height) * bytes_per_pixel) as usize];
-//     for row in 0..height {
-//         let data_begin = (row * (width * bytes_per_pixel)) as usize;
-//         let data_end = ((row + 1) * (width * bytes_per_pixel)) as usize;
-//         let slice_begin = (row * mapped.RowPitch) as usize;
-//         let slice_end = slice_begin + (width * bytes_per_pixel) as usize;
-//         data[data_begin..data_end].copy_from_slice(&slice[slice_begin..slice_end]);
-//     }
-
-//     // Unmap the texture
-//     d3d_context.unmap(&d3d_texture, 0);
-
-//     // Save the bits
-//     let image: image::ImageBuffer<image::Bgra<u8>, _> =
-//         image::ImageBuffer::from_raw(width, height, data).unwrap();
-//     // The image crate doesn't seem to support saving bgra8 :(
-//     let dynamic_image = image::DynamicImage::ImageBgra8(image);
-//     let dynamic_image = dynamic_image.to_rgba();
-//     dynamic_image.save(path).unwrap();
-
-//     Ok(())
-// }
-
-pub fn encode_d3d_surface(
-    device: &IDirect3DDevice,
+pub fn encode_d3d_surface_with_device(
+    d3d_device: &D3D11Device,
     surface: &IDirect3DSurface,
-) -> winrt::Result<image::FlatSamples<Vec<u8>>>
-{
-    let d3d_device = D3D11Device::from_direct3d_device(device)?;
+) -> winrt::Result<image::FlatSamples<Vec<u8>>> {
     let d3d_context = d3d_device.get_immediate_context();
     let d3d_texture = D3D11Texture2D::from_direct3d_surface(surface)?;
 
@@ -135,10 +64,6 @@ pub fn encode_d3d_surface(
     // Save the bits
     let image: image::ImageBuffer<image::Bgra<u8>, _> =
         image::ImageBuffer::from_raw(width, height, data).unwrap();
-    // // The image crate doesn't seem to support saving bgra8 :(
-    // let dynamic_image = image::DynamicImage::ImageBgra8(image);
-    // let dynamic_image = dynamic_image.to_rgba();
-    // dynamic_image.save(path).unwrap();
 
     Ok(image.into_flat_samples())
 }

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -9,10 +9,6 @@ winrt::import!(
 );
 
 use crate::{ImageOnHeap, PlatformApi, Result, WindowId, WindowList};
-// use image::flat::{SampleLayout, View};
-// use image::{Bgra, ColorType, FlatSamples, GenericImageView};
-// use std::{convert::TryInto, ops::DerefMut};
-use crate::win::windows::graphics::directx::direct3d11::IDirect3DDevice;
 
 use winapi::shared::minwindef::{BOOL, FALSE, INT, LPARAM, MAX_PATH, TRUE};
 // use winapi::shared::ntdef::LONG;

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,25 +1,27 @@
 use crate::{ImageOnHeap, PlatformApi, Result, WindowId, WindowList};
-use image::flat::{SampleLayout, View};
-use image::{Bgra, ColorType, FlatSamples, GenericImageView};
-use std::{convert::TryInto, ops::DerefMut};
+// use image::flat::{SampleLayout, View};
+// use image::{Bgra, ColorType, FlatSamples, GenericImageView};
+// use std::{convert::TryInto, ops::DerefMut};
+use crate::windows::graphics::directx::direct3d11::IDirect3DDevice;
 
 use winapi::shared::minwindef::{BOOL, FALSE, INT, LPARAM, MAX_PATH, TRUE};
 // use winapi::shared::ntdef::LONG;
-use winapi::shared::windef::{HDC, HGDIOBJ, HWND, LPRECT, RECT};
-use winapi::um::wingdi::{
-    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteObject, GetDIBits, GetObjectW,
-    SelectObject, SetStretchBltMode, StretchBlt, BITMAP, BITMAPINFO, BITMAPINFOHEADER, BI_RGB,
-    DIB_RGB_COLORS, HALFTONE, SRCCOPY,
-};
+use winapi::shared::windef::{HWND, RECT};
+// use winapi::um::wingdi::{
+//     BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteObject, GetDIBits, GetObjectW,
+//     SelectObject, SetStretchBltMode, StretchBlt, BITMAP, BITMAPINFO, BITMAPINFOHEADER, BI_RGB,
+//     DIB_RGB_COLORS, HALFTONE, SRCCOPY,
+// };
 use winapi::um::winnt::WCHAR;
 use winapi::um::winuser::{
-    EnumChildWindows, EnumWindows, FindWindowW, GetClientRect, GetDC, GetDesktopWindow,
-    GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
-    GetWindowThreadProcessId, MonitorFromWindow, ReleaseDC, GWL_STYLE, MONITOR_DEFAULTTOPRIMARY,
-    SM_CXSCREEN, SM_CYSCREEN, WS_SYSMENU, WS_VISIBLE,
+    EnumWindows, GetForegroundWindow, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW,
+    GetWindowTextW, GWL_STYLE, WS_SYSMENU, WS_VISIBLE,
 };
 
-use std::{mem::MaybeUninit, os::raw::c_void};
+mod capture;
+mod d3d;
+mod encoder;
+mod snapshot;
 
 #[derive(Debug)]
 pub struct Margin {
@@ -29,59 +31,69 @@ pub struct Margin {
     pub left: u16,
 }
 
-impl Margin {
-    pub fn new(top: u16, right: u16, bottom: u16, left: u16) -> Self {
-        Self {
-            top,
-            right,
-            bottom,
-            left,
-        }
-    }
-
-    pub fn new_equal(margin: u16) -> Self {
-        Self::new(margin, margin, margin, margin)
-    }
-
-    pub fn zero() -> Self {
-        Self::new_equal(0)
-    }
-
-    pub fn is_zero(&self) -> bool {
-        self.top == 0
-            && self.right == self.left
-            && self.left == self.bottom
-            && self.bottom == self.top
-    }
+struct CaptureTarget {
+    hwnd: HWND,
+    // capture_item: crate::windows::graphics::capture::GraphicsCaptureItem,
+    capture_session: snapshot::CaptureSnapshot,
+    device: IDirect3DDevice,
 }
+
+unsafe impl Send for CaptureTarget {}
+
+// impl Margin {
+//     pub fn new(top: u16, right: u16, bottom: u16, left: u16) -> Self {
+//         Self {
+//             top,
+//             right,
+//             bottom,
+//             left,
+//         }
+//     }
+
+//     pub fn new_equal(margin: u16) -> Self {
+//         Self::new(margin, margin, margin, margin)
+//     }
+
+//     pub fn zero() -> Self {
+//         Self::new_equal(0)
+//     }
+
+//     pub fn is_zero(&self) -> bool {
+//         self.top == 0
+//             && self.right == self.left
+//             && self.left == self.bottom
+//             && self.bottom == self.top
+//     }
+// }
 
 pub fn enumerate_windows<F>(mut callback: F)
 where
     F: FnMut(HWND) -> bool,
 {
     use core::mem;
-    let mut trait_obj: &mut FnMut(HWND) -> bool = &mut callback;
-    let closure_pointer_pointer: *mut c_void = unsafe { mem::transmute(&mut trait_obj) };
+    let mut trait_obj: &mut dyn FnMut(HWND) -> bool = &mut callback;
+    let closure_pointer_pointer: *mut core::ffi::c_void = unsafe { mem::transmute(&mut trait_obj) };
 
     let lparam = closure_pointer_pointer as LPARAM;
     unsafe { EnumWindows(Some(enumerate_callback), lparam) };
 }
 
-pub fn enumerate_child_windows<F>(hwnd: HWND, mut callback: F)
-where
-    F: FnMut(HWND) -> bool,
-{
-    use core::mem;
-    let mut trait_obj: &mut FnMut(HWND) -> bool = &mut callback;
-    let closure_pointer_pointer: *mut c_void = unsafe { mem::transmute(&mut trait_obj) };
+// pub fn enumerate_child_windows<F>(hwnd: HWND, mut callback: F)
+// where
+//     F: FnMut(HWND) -> bool,
+// {
+//     use core::mem;
+//     let mut trait_obj: &mut dyn FnMut(HWND) -> bool = &mut callback;
+//     let closure_pointer_pointer: *mut c_void = unsafe { mem::transmute(&mut trait_obj) };
 
-    let lparam = closure_pointer_pointer as LPARAM;
-    unsafe { EnumChildWindows(hwnd, Some(enumerate_callback), lparam) };
-}
+//     let lparam = closure_pointer_pointer as LPARAM;
+//     unsafe { EnumChildWindows(hwnd, Some(enumerate_callback), lparam) };
+// }
 
 unsafe extern "system" fn enumerate_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
     use core::mem;
-    let closure: &mut &mut FnMut(HWND) -> bool = mem::transmute(lparam as *mut c_void);
+    let closure: &mut &mut dyn FnMut(HWND) -> bool =
+        mem::transmute(lparam as *mut core::ffi::c_void);
     if closure(hwnd) {
         TRUE
     } else {
@@ -89,16 +101,21 @@ unsafe extern "system" fn enumerate_callback(hwnd: HWND, lparam: LPARAM) -> BOOL
     }
 }
 
+use std::sync::{Arc, Mutex};
+
 pub struct WinApi {
-    // conn: RustConnection<DefaultStream>,
-    // screen_num: usize,
-    // atoms: Atoms,
-    margin: Option<Margin>,
+    cap: Arc<Mutex<Option<CaptureTarget>>>,
 }
 
 impl WinApi {
     pub fn new() -> Result<Self> {
-        Ok(WinApi { margin: None })
+        // let factory =
+        //     winrt::activation::factory::<GraphicsCaptureItem, winrt::IActivationFactory>()?;
+        // cap = factory.try_into()?;
+
+        Ok(WinApi {
+            cap: Arc::new(Mutex::new(None)),
+        })
     }
 }
 
@@ -110,7 +127,7 @@ impl PlatformApi for WinApi {
     /// 1. it does check for the screenshot
     /// 2. it checks for transparent margins and configures the api
     ///     to cut them away in further screenshots
-    fn calibrate(&mut self, window_id: WindowId) -> Result<()> {
+    fn calibrate(&mut self, _window_id: WindowId) -> Result<()> {
         // let image = self.capture_window_screenshot(window_id)?;
         // let image: View<_, Bgra<u8>> = image.as_view()?;
         // let (width, height) = image.dimensions();
@@ -207,297 +224,43 @@ impl PlatformApi for WinApi {
     }
 
     fn capture_window_screenshot(&self, window_id: WindowId) -> Result<ImageOnHeap> {
-        let window_id = 198478;
         let hwnd = window_id as HWND;
+        let mut mtx = self.cap.lock().unwrap();
+        match &*mtx {
+            None => {
+                let cap = capture::create_capture_item_for_window(hwnd).unwrap();
+                let d3d_device = d3d::D3D11Device::new().unwrap();
+                let device = d3d_device.to_direct3d_device().unwrap();
+                let session = snapshot::CaptureSnapshot::create_session(&device, &cap).unwrap();
+                *mtx = Some(CaptureTarget {
+                    hwnd,
+                    capture_session: session,
+                    device,
+                });
+            }
+            Some(ct) => {
+                if ct.hwnd != hwnd {
+                    let cap = capture::create_capture_item_for_window(hwnd).unwrap();
+                    let d3d_device = d3d::D3D11Device::new().unwrap();
+                    let device = d3d_device.to_direct3d_device().unwrap();
+                    let session = snapshot::CaptureSnapshot::create_session(&device, &cap).unwrap();
 
-        // let (_, _, mut width, mut height) = self.get_window_geometry(&window_id)?;
-        // let (mut x, mut y) = (0_i16, 0_i16);
-        // if self.margin.is_some() {
-        //     let margin = self.margin.as_ref().unwrap();
-        //     width -= margin.left + margin.right;
-        //     height -= margin.top + margin.bottom;
-        //     x = margin.left as i16;
-        //     y = margin.top as i16;
-        // }
-        // let image = self
-        //     .conn
-        //     // NOTE: x and y are not the absolute coordinates but relative to the windows dimensions, that is why 0, 0
-        //     .get_image(
-        //         ImageFormat::ZPixmap,
-        //         window_id as Drawable,
-        //         x,
-        //         y,
-        //         width,
-        //         height,
-        //         !0,
-        //     )?
-        //     .reply()
-        //     .context(format!(
-        //         "Cannot fetch the image data for window {}",
-        //         window_id
-        //     ))?;
-
-
-        // println!("Buffer data: {:?}", raw_data);
-        let buffer = capture_window_screenshot_1(hwnd)?;
-
-        // // NOTE: in this case the alpha channel is 0, but should be set to 0xff
-        // if image.depth == 24 {
-        //     // the index into the alpha channel
-        //     let mut i = 3;
-        //     let len = buffer.samples.len();
-        //     while i < len {
-        //         let alpha = buffer.samples.get_mut(i).unwrap();
-        //         if alpha == &0 {
-        //             *alpha = 0xff;
-        //         } else {
-        //             // NOTE: the assumption here is, if one pixel is fine, then all might be fine :)
-        //             break;
-        //         }
-
-        //         // going one pixel further, still pointing to the alpha channel
-        //         i += buffer.layout.width_stride;
-        //     }
-        // }
+                    *mtx = Some(CaptureTarget {
+                        hwnd,
+                        capture_session: session,
+                        device,
+                    });
+                }
+            }
+        }
+        let ct = mtx.as_ref().unwrap();
+        let surface = ct.capture_session.take_session().unwrap();
+        let buffer = encoder::encode_d3d_surface(&ct.device, &surface).unwrap();
 
         Ok(ImageOnHeap::new(buffer))
     }
 
     fn get_active_window(&self) -> Result<WindowId> {
-        println!("Getting active window");
-        // let screen = self.screen();
-        // let conn = &self.conn;
-        // let atoms = &self.atoms;
-        // let prop = conn
-        //     .get_property(
-        //         false,
-        //         screen.root,
-        //         atoms._NET_ACTIVE_WINDOW,
-        //         AtomEnum::WINDOW,
-        //         0,
-        //         u32::MAX,
-        //     )?
-        //     .reply()?;
-        // let window = prop.value32().unwrap().next().unwrap();
-
-        Ok(0 as WindowId)
+        Ok(unsafe { GetForegroundWindow() } as WindowId)
     }
 }
-
-struct DeviceContext {
-    hdc: HDC,
-    hwnd: HWND,
-}
-
-impl DeviceContext {
-    pub fn get_dc(hwnd: Option<HWND>) -> Result<DeviceContext> {
-        let hwnd = hwnd.unwrap_or(0 as HWND);
-        let hdc = unsafe { GetDC(hwnd) };
-        if hdc.is_null() {
-            return Err(anyhow::Error::msg("Unable to get device context"));
-        }
-        Ok(DeviceContext { hdc, hwnd })
-    }
-    pub fn as_mut_ptr(&mut self) -> HDC {
-        self.hdc
-    }
-}
-
-impl Drop for DeviceContext {
-    fn drop(&mut self) {
-        unsafe { ReleaseDC(self.hwnd, self.hdc) };
-    }
-}
-
-/// Capture a screenshot of the specified window. This function works
-/// by capturing the entire screen and then cropping the coordinates of the
-/// specified window.
-fn capture_window_screenshot_1(hwnd: HWND) -> Result<FlatSamples<Vec<u8>>> {
-    println!("Capturing window");
-
-    // Retrieve the handle to a display device context for the client
-    // area of the window.
-    let mut screen = DeviceContext::get_dc(None)?; //unsafe { GetDC(0 as HWND) };
-    let mut window = DeviceContext::get_dc(Some(hwnd))?; //unsafe { GetDC(hwnd) };
-
-    // Create a compatible DC, which is used in a BitBlt from the window DC.
-    let mem_dc = unsafe { CreateCompatibleDC(window.as_mut_ptr()) };
-    if mem_dc.is_null() {
-        return Err(anyhow::Error::msg(
-            "Unable to create drawing context for window",
-        ));
-    }
-
-    // Figure out the dimensions and position of the window of interest.
-    let mut client_rect = core::mem::MaybeUninit::<RECT>::uninit();
-    unsafe { GetClientRect(hwnd, client_rect.as_mut_ptr() as LPRECT) };
-    let client_rect = unsafe { client_rect.assume_init() };
-
-    // This is the best stretch mode.
-    unsafe { SetStretchBltMode(window.as_mut_ptr(), HALFTONE) };
-
-    // The source DC is the entire screen, and the destination DC is the current window (HWND).
-    if unsafe {
-        StretchBlt(
-            mem_dc,
-            0,
-            0,
-            client_rect.right,
-            client_rect.bottom,
-            screen.as_mut_ptr(),
-            0,
-            0,
-            GetSystemMetrics(SM_CXSCREEN),
-            GetSystemMetrics(SM_CYSCREEN),
-            SRCCOPY,
-        ) == FALSE
-    } {
-        // Clean up
-        // ReleaseDC(NULL, screen);
-        // ReleaseDC(hwnd, window);
-        // MessageBox(hWnd, L"CreateCompatibleDC has failed", L"Failed", MB_OK);
-        // goto done;
-        return Err(anyhow::Error::msg("StretchBlit failed"));
-    }
-
-    // Create a compatible bitmap from the Window DC.
-    let screen_bmp = unsafe {
-        CreateCompatibleBitmap(
-            window.as_mut_ptr(),
-            client_rect.right - client_rect.left,
-            client_rect.bottom - client_rect.top,
-        )
-    };
-
-    if screen_bmp.is_null() {
-        // Clean up
-        // DeleteObject(screen);
-        // ReleaseDC(NULL, screen);
-        // ReleaseDC(hwnd, window);
-        // MessageBox(hWnd, L"CreateCompatibleDC has failed", L"Failed", MB_OK);
-        // goto done;
-        return Err(anyhow::Error::msg("Unable to create screen bitmap"));
-    }
-
-    // Select the compatible bitmap into the compatible memory DC.
-    unsafe { SelectObject(mem_dc, screen_bmp as HGDIOBJ) };
-
-    // Bit block transfer into our compatible memory DC.
-    if unsafe {
-        BitBlt(
-            mem_dc,
-            0,
-            0,
-            client_rect.right - client_rect.left,
-            client_rect.bottom - client_rect.top,
-            window.as_mut_ptr(),
-            0,
-            0,
-            SRCCOPY,
-        )
-    } == FALSE
-    {
-        // // Clean up
-        // unsafe { DeleteObject(mem_dc as _) };
-        // unsafe { DeleteObject(screen as _) };
-        // unsafe { ReleaseDC(0 as HWND, screen) };
-        // unsafe { ReleaseDC(hwnd, window.as_mut_ptr()) };
-        // goto done;
-        return Err(anyhow::Error::msg("BitBlt has failed"));
-    }
-
-    // Get the BITMAP from the HBITMAP.
-    let mut bmp_screen = core::mem::MaybeUninit::<BITMAP>::uninit();
-    unsafe {
-        GetObjectW(
-            screen_bmp as *mut _,
-            core::mem::size_of::<BITMAP>().try_into().unwrap(),
-            bmp_screen.as_mut_ptr() as *mut _,
-        )
-    };
-    let bmp_screen = unsafe { bmp_screen.assume_init() };
-
-    let mut bi = BITMAPINFOHEADER {
-        biSize: core::mem::size_of::<BITMAPINFOHEADER>().try_into().unwrap(),
-        biWidth: bmp_screen.bmWidth,
-        biHeight: bmp_screen.bmHeight,
-        biPlanes: 1,
-        biBitCount: 32,
-        biCompression: BI_RGB,
-        biSizeImage: 0,
-        biXPelsPerMeter: 0,
-        biYPelsPerMeter: 0,
-        biClrUsed: 0,
-        biClrImportant: 0,
-    };
-
-    println!(
-        "Width: {}  Height: {}  Bitcount: {}",
-        bmp_screen.bmWidth, bmp_screen.bmHeight, bi.biBitCount
-    );
-    let mut raw_data = vec![
-        0u8;
-        (((bmp_screen.bmWidth as usize) * (bi.biBitCount as usize) + 31) / 32)
-            * 4
-            * (bmp_screen.bmHeight as usize)
-    ];
-
-    // Gets the "bits" from the bitmap, and copies them into a buffer
-    // that's pointed to by lpbitmap.
-    unsafe {
-        GetDIBits(
-            window.as_mut_ptr(),
-            screen_bmp,
-            0,
-            bmp_screen.bmHeight as _,
-            raw_data.as_mut_ptr() as *mut _,
-            &mut bi as *mut BITMAPINFOHEADER as *mut BITMAPINFO,
-            DIB_RGB_COLORS,
-        )
-    };
-
-    let color = ColorType::Bgra8;
-    let channels = 4;
-
-    Ok(FlatSamples {
-        samples: raw_data,
-        layout: SampleLayout::row_major_packed(
-            channels,
-            bmp_screen.bmWidth as u32,
-            bmp_screen.bmHeight as u32,
-        ),
-        color_hint: Some(color),
-    })
-}
-
-// fn capture_window_screenshot_2(hwnd: HWND) -> Result<FlatSamples<Vec<u8>>>{
-
-//     // let window: Vec<u16> = OsStr::new(name).encode_wide().chain(once(0)).collect();
-
-//     // let hwnd = unsafe { FindWindowW(null_mut(), window.as_ptr()) };
-
-//     // if hwnd != null_mut() {
-//         println!("Window found");
-
-//         let mut my_rect = unsafe { core::mem::zeroed::<RECT>() };
-//         let _client_rect = unsafe { GetClientRect(hwnd, &mut my_rect) };
-//         let w = my_rect.right - my_rect.left;
-//         let h = my_rect.bottom - my_rect.top;
-
-//         let hwnd_dc = unsafe { GetWindowDC(hwnd) };
-//         let mem_dc = unsafe { CreateCompatibleDC(hwnd_dc) };
-//         let bmp = unsafe { CreateCompatibleBitmap(mem_dc, w, h) };
-
-//         //SelectObject(mem_dc, bmp); <== Problem is here
-
-//         //DeleteObject(bmp); <== Same problem here
-//         unsafe { DeleteDC(mem_dc) };
-//         unsafe { ReleaseDC(hwnd, hwnd_dc) };
-//     // }
-//     // else {
-//     //     println!("Window not found");
-//     // }
-// }
-
-// references for winRT
-// https://github.com/robmikh/wgc-rust-demo/blob/master/src/main.rs

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,12 +1,503 @@
-use crate::{ImageOnHeap, WindowList};
+use crate::{ImageOnHeap, PlatformApi, Result, WindowId, WindowList};
+use image::flat::{SampleLayout, View};
+use image::{Bgra, ColorType, FlatSamples, GenericImageView};
+use std::{convert::TryInto, ops::DerefMut};
 
-pub fn window_list() -> anyhow::Result<WindowList> {
-    unimplemented!("there is only an impl for MacOS")
+use winapi::shared::minwindef::{BOOL, FALSE, INT, LPARAM, MAX_PATH, TRUE};
+// use winapi::shared::ntdef::LONG;
+use winapi::shared::windef::{HDC, HGDIOBJ, HWND, LPRECT, RECT};
+use winapi::um::wingdi::{
+    BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteObject, GetDIBits, GetObjectW,
+    SelectObject, SetStretchBltMode, StretchBlt, BITMAP, BITMAPINFO, BITMAPINFOHEADER, BI_RGB,
+    DIB_RGB_COLORS, HALFTONE, SRCCOPY,
+};
+use winapi::um::winnt::WCHAR;
+use winapi::um::winuser::{
+    EnumChildWindows, EnumWindows, FindWindowW, GetClientRect, GetDC, GetDesktopWindow,
+    GetSystemMetrics, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
+    GetWindowThreadProcessId, MonitorFromWindow, ReleaseDC, GWL_STYLE, MONITOR_DEFAULTTOPRIMARY,
+    SM_CXSCREEN, SM_CYSCREEN, WS_SYSMENU, WS_VISIBLE,
+};
+
+use std::{mem::MaybeUninit, os::raw::c_void};
+
+#[derive(Debug)]
+pub struct Margin {
+    pub top: u16,
+    pub right: u16,
+    pub bottom: u16,
+    pub left: u16,
 }
 
-pub fn capture_window_screenshot(_win_id: u64) -> anyhow::Result<ImageOnHeap> {
-    unimplemented!("there is only an impl for MacOS")
+impl Margin {
+    pub fn new(top: u16, right: u16, bottom: u16, left: u16) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
+    }
+
+    pub fn new_equal(margin: u16) -> Self {
+        Self::new(margin, margin, margin, margin)
+    }
+
+    pub fn zero() -> Self {
+        Self::new_equal(0)
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.top == 0
+            && self.right == self.left
+            && self.left == self.bottom
+            && self.bottom == self.top
+    }
 }
+
+pub fn enumerate_windows<F>(mut callback: F)
+where
+    F: FnMut(HWND) -> bool,
+{
+    use core::mem;
+    let mut trait_obj: &mut FnMut(HWND) -> bool = &mut callback;
+    let closure_pointer_pointer: *mut c_void = unsafe { mem::transmute(&mut trait_obj) };
+
+    let lparam = closure_pointer_pointer as LPARAM;
+    unsafe { EnumWindows(Some(enumerate_callback), lparam) };
+}
+
+pub fn enumerate_child_windows<F>(hwnd: HWND, mut callback: F)
+where
+    F: FnMut(HWND) -> bool,
+{
+    use core::mem;
+    let mut trait_obj: &mut FnMut(HWND) -> bool = &mut callback;
+    let closure_pointer_pointer: *mut c_void = unsafe { mem::transmute(&mut trait_obj) };
+
+    let lparam = closure_pointer_pointer as LPARAM;
+    unsafe { EnumChildWindows(hwnd, Some(enumerate_callback), lparam) };
+}
+
+unsafe extern "system" fn enumerate_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    use core::mem;
+    let closure: &mut &mut FnMut(HWND) -> bool = mem::transmute(lparam as *mut c_void);
+    if closure(hwnd) {
+        TRUE
+    } else {
+        FALSE
+    }
+}
+
+pub struct WinApi {
+    // conn: RustConnection<DefaultStream>,
+    // screen_num: usize,
+    // atoms: Atoms,
+    margin: Option<Margin>,
+}
+
+impl WinApi {
+    pub fn new() -> Result<Self> {
+        Ok(WinApi { margin: None })
+    }
+}
+
+pub fn setup() -> Result<Box<dyn PlatformApi>> {
+    Ok(Box::new(WinApi::new()?))
+}
+
+impl PlatformApi for WinApi {
+    /// 1. it does check for the screenshot
+    /// 2. it checks for transparent margins and configures the api
+    ///     to cut them away in further screenshots
+    fn calibrate(&mut self, window_id: WindowId) -> Result<()> {
+        // let image = self.capture_window_screenshot(window_id)?;
+        // let image: View<_, Bgra<u8>> = image.as_view()?;
+        // let (width, height) = image.dimensions();
+        // let half_width = width / 2;
+        // let half_height = height / 2;
+
+        // let mut margin = Margin::zero();
+        // // identify top margin
+        // for y in 0..half_height {
+        //     let Bgra([_, _, _, a]) = image.get_pixel(half_width, y);
+        //     if a == 0xff {
+        //         // the end of the transparent area
+        //         margin.top = y as u16;
+        //         dbg!(margin.top);
+        //         break;
+        //     }
+        // }
+        // // identify bottom margin
+        // for y in (half_height..height).rev() {
+        //     let Bgra([_, _, _, a]) = image.get_pixel(half_width, y);
+        //     if a == 0xff {
+        //         // the end of the transparent area
+        //         margin.bottom = (height - y - 1) as u16;
+        //         dbg!(margin.bottom);
+        //         break;
+        //     }
+        // }
+        // // identify left margin
+        // for x in 0..half_width {
+        //     let Bgra([_, _, _, a]) = image.get_pixel(x, half_height);
+        //     if a == 0xff {
+        //         // the end of the transparent area
+        //         margin.left = x as u16;
+        //         dbg!(margin.left);
+        //         break;
+        //     }
+        // }
+        // // identify right margin
+        // for x in (half_width..width).rev() {
+        //     let Bgra([_, _, _, a]) = image.get_pixel(x, half_height);
+        //     if a == 0xff {
+        //         // the end of the transparent area
+        //         margin.right = (width - x - 1) as u16;
+        //         dbg!(margin.right);
+        //         break;
+        //     }
+        // }
+        // self.margin = if margin.is_zero() { None } else { Some(margin) };
+
+        Ok(())
+    }
+
+    fn window_list(&self) -> Result<WindowList> {
+        use std::ffi::OsString;
+        use std::os::windows::prelude::*;
+        let mut wins = vec![];
+        enumerate_windows(|hwnd| {
+            // Skip invisible windows
+            let style = unsafe { GetWindowLongPtrW(hwnd, GWL_STYLE) } as u32;
+            if ((style & WS_VISIBLE) != WS_VISIBLE) || ((style & WS_SYSMENU) != WS_SYSMENU) {
+                return true;
+            }
+
+            // Skip empty window titles
+            let length = unsafe { GetWindowTextLengthW(hwnd) } as usize;
+            if length == 0 {
+                return true;
+            }
+
+            // Retrieve the title. Add 1 for the null terminator.
+            let mut title = [0 as WCHAR; MAX_PATH as usize];
+            unsafe { GetWindowTextW(hwnd, title.as_mut_ptr(), 1 + length as INT) };
+
+            // Convert the title to a UTF-8 string
+            let string = OsString::from_wide(&title[0..length]);
+            if let Ok(s) = string.into_string() {
+                let mut rect = core::mem::MaybeUninit::<RECT>::uninit();
+                let name = if TRUE == unsafe { GetWindowRect(hwnd, rect.as_mut_ptr() as _) } {
+                    let rect = unsafe { rect.assume_init() };
+                    format!(
+                        "{} ({}x{})",
+                        s,
+                        rect.right - rect.left,
+                        rect.bottom - rect.top
+                    )
+                } else {
+                    s
+                };
+                wins.push((Some(name), hwnd as WindowId));
+            }
+            true
+        });
+        Ok(wins)
+    }
+
+    fn capture_window_screenshot(&self, window_id: WindowId) -> Result<ImageOnHeap> {
+        let window_id = 198478;
+        let hwnd = window_id as HWND;
+
+        // let (_, _, mut width, mut height) = self.get_window_geometry(&window_id)?;
+        // let (mut x, mut y) = (0_i16, 0_i16);
+        // if self.margin.is_some() {
+        //     let margin = self.margin.as_ref().unwrap();
+        //     width -= margin.left + margin.right;
+        //     height -= margin.top + margin.bottom;
+        //     x = margin.left as i16;
+        //     y = margin.top as i16;
+        // }
+        // let image = self
+        //     .conn
+        //     // NOTE: x and y are not the absolute coordinates but relative to the windows dimensions, that is why 0, 0
+        //     .get_image(
+        //         ImageFormat::ZPixmap,
+        //         window_id as Drawable,
+        //         x,
+        //         y,
+        //         width,
+        //         height,
+        //         !0,
+        //     )?
+        //     .reply()
+        //     .context(format!(
+        //         "Cannot fetch the image data for window {}",
+        //         window_id
+        //     ))?;
+
+
+        // println!("Buffer data: {:?}", raw_data);
+        let buffer = capture_window_screenshot_1(hwnd)?;
+
+        // // NOTE: in this case the alpha channel is 0, but should be set to 0xff
+        // if image.depth == 24 {
+        //     // the index into the alpha channel
+        //     let mut i = 3;
+        //     let len = buffer.samples.len();
+        //     while i < len {
+        //         let alpha = buffer.samples.get_mut(i).unwrap();
+        //         if alpha == &0 {
+        //             *alpha = 0xff;
+        //         } else {
+        //             // NOTE: the assumption here is, if one pixel is fine, then all might be fine :)
+        //             break;
+        //         }
+
+        //         // going one pixel further, still pointing to the alpha channel
+        //         i += buffer.layout.width_stride;
+        //     }
+        // }
+
+        Ok(ImageOnHeap::new(buffer))
+    }
+
+    fn get_active_window(&self) -> Result<WindowId> {
+        println!("Getting active window");
+        // let screen = self.screen();
+        // let conn = &self.conn;
+        // let atoms = &self.atoms;
+        // let prop = conn
+        //     .get_property(
+        //         false,
+        //         screen.root,
+        //         atoms._NET_ACTIVE_WINDOW,
+        //         AtomEnum::WINDOW,
+        //         0,
+        //         u32::MAX,
+        //     )?
+        //     .reply()?;
+        // let window = prop.value32().unwrap().next().unwrap();
+
+        Ok(0 as WindowId)
+    }
+}
+
+struct DeviceContext {
+    hdc: HDC,
+    hwnd: HWND,
+}
+
+impl DeviceContext {
+    pub fn get_dc(hwnd: Option<HWND>) -> Result<DeviceContext> {
+        let hwnd = hwnd.unwrap_or(0 as HWND);
+        let hdc = unsafe { GetDC(hwnd) };
+        if hdc.is_null() {
+            return Err(anyhow::Error::msg("Unable to get device context"));
+        }
+        Ok(DeviceContext { hdc, hwnd })
+    }
+    pub fn as_mut_ptr(&mut self) -> HDC {
+        self.hdc
+    }
+}
+
+impl Drop for DeviceContext {
+    fn drop(&mut self) {
+        unsafe { ReleaseDC(self.hwnd, self.hdc) };
+    }
+}
+
+/// Capture a screenshot of the specified window. This function works
+/// by capturing the entire screen and then cropping the coordinates of the
+/// specified window.
+fn capture_window_screenshot_1(hwnd: HWND) -> Result<FlatSamples<Vec<u8>>> {
+    println!("Capturing window");
+
+    // Retrieve the handle to a display device context for the client
+    // area of the window.
+    let mut screen = DeviceContext::get_dc(None)?; //unsafe { GetDC(0 as HWND) };
+    let mut window = DeviceContext::get_dc(Some(hwnd))?; //unsafe { GetDC(hwnd) };
+
+    // Create a compatible DC, which is used in a BitBlt from the window DC.
+    let mem_dc = unsafe { CreateCompatibleDC(window.as_mut_ptr()) };
+    if mem_dc.is_null() {
+        return Err(anyhow::Error::msg(
+            "Unable to create drawing context for window",
+        ));
+    }
+
+    // Figure out the dimensions and position of the window of interest.
+    let mut client_rect = core::mem::MaybeUninit::<RECT>::uninit();
+    unsafe { GetClientRect(hwnd, client_rect.as_mut_ptr() as LPRECT) };
+    let client_rect = unsafe { client_rect.assume_init() };
+
+    // This is the best stretch mode.
+    unsafe { SetStretchBltMode(window.as_mut_ptr(), HALFTONE) };
+
+    // The source DC is the entire screen, and the destination DC is the current window (HWND).
+    if unsafe {
+        StretchBlt(
+            mem_dc,
+            0,
+            0,
+            client_rect.right,
+            client_rect.bottom,
+            screen.as_mut_ptr(),
+            0,
+            0,
+            GetSystemMetrics(SM_CXSCREEN),
+            GetSystemMetrics(SM_CYSCREEN),
+            SRCCOPY,
+        ) == FALSE
+    } {
+        // Clean up
+        // ReleaseDC(NULL, screen);
+        // ReleaseDC(hwnd, window);
+        // MessageBox(hWnd, L"CreateCompatibleDC has failed", L"Failed", MB_OK);
+        // goto done;
+        return Err(anyhow::Error::msg("StretchBlit failed"));
+    }
+
+    // Create a compatible bitmap from the Window DC.
+    let screen_bmp = unsafe {
+        CreateCompatibleBitmap(
+            window.as_mut_ptr(),
+            client_rect.right - client_rect.left,
+            client_rect.bottom - client_rect.top,
+        )
+    };
+
+    if screen_bmp.is_null() {
+        // Clean up
+        // DeleteObject(screen);
+        // ReleaseDC(NULL, screen);
+        // ReleaseDC(hwnd, window);
+        // MessageBox(hWnd, L"CreateCompatibleDC has failed", L"Failed", MB_OK);
+        // goto done;
+        return Err(anyhow::Error::msg("Unable to create screen bitmap"));
+    }
+
+    // Select the compatible bitmap into the compatible memory DC.
+    unsafe { SelectObject(mem_dc, screen_bmp as HGDIOBJ) };
+
+    // Bit block transfer into our compatible memory DC.
+    if unsafe {
+        BitBlt(
+            mem_dc,
+            0,
+            0,
+            client_rect.right - client_rect.left,
+            client_rect.bottom - client_rect.top,
+            window.as_mut_ptr(),
+            0,
+            0,
+            SRCCOPY,
+        )
+    } == FALSE
+    {
+        // // Clean up
+        // unsafe { DeleteObject(mem_dc as _) };
+        // unsafe { DeleteObject(screen as _) };
+        // unsafe { ReleaseDC(0 as HWND, screen) };
+        // unsafe { ReleaseDC(hwnd, window.as_mut_ptr()) };
+        // goto done;
+        return Err(anyhow::Error::msg("BitBlt has failed"));
+    }
+
+    // Get the BITMAP from the HBITMAP.
+    let mut bmp_screen = core::mem::MaybeUninit::<BITMAP>::uninit();
+    unsafe {
+        GetObjectW(
+            screen_bmp as *mut _,
+            core::mem::size_of::<BITMAP>().try_into().unwrap(),
+            bmp_screen.as_mut_ptr() as *mut _,
+        )
+    };
+    let bmp_screen = unsafe { bmp_screen.assume_init() };
+
+    let mut bi = BITMAPINFOHEADER {
+        biSize: core::mem::size_of::<BITMAPINFOHEADER>().try_into().unwrap(),
+        biWidth: bmp_screen.bmWidth,
+        biHeight: bmp_screen.bmHeight,
+        biPlanes: 1,
+        biBitCount: 32,
+        biCompression: BI_RGB,
+        biSizeImage: 0,
+        biXPelsPerMeter: 0,
+        biYPelsPerMeter: 0,
+        biClrUsed: 0,
+        biClrImportant: 0,
+    };
+
+    println!(
+        "Width: {}  Height: {}  Bitcount: {}",
+        bmp_screen.bmWidth, bmp_screen.bmHeight, bi.biBitCount
+    );
+    let mut raw_data = vec![
+        0u8;
+        (((bmp_screen.bmWidth as usize) * (bi.biBitCount as usize) + 31) / 32)
+            * 4
+            * (bmp_screen.bmHeight as usize)
+    ];
+
+    // Gets the "bits" from the bitmap, and copies them into a buffer
+    // that's pointed to by lpbitmap.
+    unsafe {
+        GetDIBits(
+            window.as_mut_ptr(),
+            screen_bmp,
+            0,
+            bmp_screen.bmHeight as _,
+            raw_data.as_mut_ptr() as *mut _,
+            &mut bi as *mut BITMAPINFOHEADER as *mut BITMAPINFO,
+            DIB_RGB_COLORS,
+        )
+    };
+
+    let color = ColorType::Bgra8;
+    let channels = 4;
+
+    Ok(FlatSamples {
+        samples: raw_data,
+        layout: SampleLayout::row_major_packed(
+            channels,
+            bmp_screen.bmWidth as u32,
+            bmp_screen.bmHeight as u32,
+        ),
+        color_hint: Some(color),
+    })
+}
+
+// fn capture_window_screenshot_2(hwnd: HWND) -> Result<FlatSamples<Vec<u8>>>{
+
+//     // let window: Vec<u16> = OsStr::new(name).encode_wide().chain(once(0)).collect();
+
+//     // let hwnd = unsafe { FindWindowW(null_mut(), window.as_ptr()) };
+
+//     // if hwnd != null_mut() {
+//         println!("Window found");
+
+//         let mut my_rect = unsafe { core::mem::zeroed::<RECT>() };
+//         let _client_rect = unsafe { GetClientRect(hwnd, &mut my_rect) };
+//         let w = my_rect.right - my_rect.left;
+//         let h = my_rect.bottom - my_rect.top;
+
+//         let hwnd_dc = unsafe { GetWindowDC(hwnd) };
+//         let mem_dc = unsafe { CreateCompatibleDC(hwnd_dc) };
+//         let bmp = unsafe { CreateCompatibleBitmap(mem_dc, w, h) };
+
+//         //SelectObject(mem_dc, bmp); <== Problem is here
+
+//         //DeleteObject(bmp); <== Same problem here
+//         unsafe { DeleteDC(mem_dc) };
+//         unsafe { ReleaseDC(hwnd, hwnd_dc) };
+//     // }
+//     // else {
+//     //     println!("Window not found");
+//     // }
+// }
 
 // references for winRT
 // https://github.com/robmikh/wgc-rust-demo/blob/master/src/main.rs

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,17 +1,22 @@
+winrt::import!(
+    dependencies
+        "os"
+    modules
+        "windows.graphics"
+        "windows.graphics.capture"
+        "windows.graphics.directx"
+        "windows.graphics.directx.direct3d11"
+);
+
 use crate::{ImageOnHeap, PlatformApi, Result, WindowId, WindowList};
 // use image::flat::{SampleLayout, View};
 // use image::{Bgra, ColorType, FlatSamples, GenericImageView};
 // use std::{convert::TryInto, ops::DerefMut};
-use crate::windows::graphics::directx::direct3d11::IDirect3DDevice;
+use crate::win::windows::graphics::directx::direct3d11::IDirect3DDevice;
 
 use winapi::shared::minwindef::{BOOL, FALSE, INT, LPARAM, MAX_PATH, TRUE};
 // use winapi::shared::ntdef::LONG;
 use winapi::shared::windef::{HWND, RECT};
-// use winapi::um::wingdi::{
-//     BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteObject, GetDIBits, GetObjectW,
-//     SelectObject, SetStretchBltMode, StretchBlt, BITMAP, BITMAPINFO, BITMAPINFOHEADER, BI_RGB,
-//     DIB_RGB_COLORS, HALFTONE, SRCCOPY,
-// };
 use winapi::um::winnt::WCHAR;
 use winapi::um::winuser::{
     EnumWindows, GetForegroundWindow, GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW,
@@ -35,7 +40,7 @@ struct CaptureTarget {
     hwnd: HWND,
     // capture_item: crate::windows::graphics::capture::GraphicsCaptureItem,
     capture_session: snapshot::CaptureSnapshot,
-    device: IDirect3DDevice,
+    // device: IDirect3DDevice,
 }
 
 unsafe impl Send for CaptureTarget {}
@@ -235,7 +240,6 @@ impl PlatformApi for WinApi {
                 *mtx = Some(CaptureTarget {
                     hwnd,
                     capture_session: session,
-                    device,
                 });
             }
             Some(ct) => {
@@ -248,15 +252,12 @@ impl PlatformApi for WinApi {
                     *mtx = Some(CaptureTarget {
                         hwnd,
                         capture_session: session,
-                        device,
                     });
                 }
             }
         }
         let ct = mtx.as_ref().unwrap();
-        let surface = ct.capture_session.take_session().unwrap();
-        let buffer = encoder::encode_d3d_surface(&ct.device, &surface).unwrap();
-
+        let buffer = ct.capture_session.snapshot().unwrap();
         Ok(ImageOnHeap::new(buffer))
     }
 

--- a/src/win/snapshot.rs
+++ b/src/win/snapshot.rs
@@ -1,19 +1,24 @@
 use super::d3d::{D3D11Device, D3D11Texture2D};
-use crate::windows::graphics::capture::{
+use crate::win::windows::graphics::capture::{
     Direct3D11CaptureFramePool, GraphicsCaptureItem, GraphicsCaptureSession,
 };
-use crate::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
-use crate::windows::graphics::directx::DirectXPixelFormat;
+use crate::win::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+use crate::win::windows::graphics::directx::DirectXPixelFormat;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use winapi::um::d3d11::{D3D11_CPU_ACCESS_READ, D3D11_USAGE_STAGING};
 
 type FrameArrivedHandler =
     crate::windows::foundation::TypedEventHandler<Direct3D11CaptureFramePool, winrt::Object>;
 
+enum TriggerCommand {
+    Capture,
+    Exit,
+}
+
 pub struct CaptureSnapshot {
     _session: GraphicsCaptureSession,
-    trigger_capture: Sender<()>,
-    image_data: Receiver<D3D11Texture2D>,
+    trigger_capture: Sender<TriggerCommand>,
+    image_data: Receiver<image::FlatSamples<Vec<u8>>>,
 }
 
 impl CaptureSnapshot {
@@ -41,27 +46,47 @@ impl CaptureSnapshot {
             let d3d_context = d3d_context.clone();
             let session = session.clone();
             move |frame_pool, _| {
-                if let Ok(()) = trigger_capture_receiver.recv() {
-                    let frame = frame_pool.try_get_next_frame()?;
-                    let surface = frame.surface()?;
+                match trigger_capture_receiver.recv() {
+                    Ok(cmd) => {
+                        match cmd {
+                            TriggerCommand::Capture => {
+                                let frame = frame_pool.try_get_next_frame()?;
+                                let surface = frame.surface()?;
 
-                    let frame_texture = D3D11Texture2D::from_direct3d_surface(&surface)?;
+                                let frame_texture =
+                                    D3D11Texture2D::from_direct3d_surface(&surface)?;
 
-                    // Make a copy of the texture
-                    let mut desc = frame_texture.get_desc();
-                    // Make this a staging texture
-                    desc.Usage = D3D11_USAGE_STAGING;
-                    desc.BindFlags = 0;
-                    desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-                    desc.MiscFlags = 0;
-                    let copy_texture = d3d_device.create_texture_2d(&desc, None)?;
-                    d3d_context.copy_resource(&copy_texture, &frame_texture);
+                                // Make a copy of the texture
+                                let mut desc = frame_texture.get_desc();
 
-                    // // End the capture
-                    // session.close()?;
-                    // frame_pool.close()?;
+                                // Make this a staging texture
+                                desc.Usage = D3D11_USAGE_STAGING;
+                                desc.BindFlags = 0;
+                                desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+                                desc.MiscFlags = 0;
+                                let copy_texture = d3d_device.create_texture_2d(&desc, None)?;
+                                d3d_context.copy_resource(&copy_texture, &frame_texture);
 
-                    image_data_sender.send(copy_texture).unwrap();
+                                let buffer = super::encoder::encode_d3d_surface_with_device(
+                                    &d3d_device,
+                                    &copy_texture.to_direct3d_surface()?,
+                                )?;
+
+                                image_data_sender.send(buffer).unwrap();
+                            }
+                            TriggerCommand::Exit => {
+                                // End the capture
+                                session.close()?;
+                                frame_pool.close()?;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        println!("Error: {}", e);
+                        // End the capture
+                        session.close()?;
+                        frame_pool.close()?;
+                    }
                 }
                 Ok(())
             }
@@ -77,75 +102,17 @@ impl CaptureSnapshot {
         })
     }
 
-    pub fn take_session(&self) -> winrt::Result<IDirect3DSurface> {
-        self.trigger_capture.send(()).unwrap();
-        // Wait for our texture to come
-        let texture = self.image_data.recv().unwrap();
-        let surface = texture.to_direct3d_surface()?;
+    pub fn snapshot(&self) -> winrt::Result<image::FlatSamples<Vec<u8>>> {
+        // Trigger a capture -- cause the next frame to get sent
+        self.trigger_capture.send(TriggerCommand::Capture).unwrap();
 
-        Ok(surface)
+        // Wait for our renderd image data to arrive
+        Ok(self.image_data.recv().unwrap())
     }
+}
 
-    // TODO: Allow to create non-staging textures
-    // TODO: Allow specifying pixel format
-    // TODO: Async?
-    pub fn take(
-        device: &IDirect3DDevice,
-        item: &GraphicsCaptureItem,
-    ) -> winrt::Result<IDirect3DSurface> {
-        let d3d_device = D3D11Device::from_direct3d_device(device)?;
-        let d3d_context = d3d_device.get_immediate_context();
-        let item_size = item.size()?;
-
-        // Initialize the capture
-        let frame_pool = Direct3D11CaptureFramePool::create_free_threaded(
-            device,
-            DirectXPixelFormat::B8G8R8A8UIntNormalized,
-            1,
-            &item_size,
-        )?;
-        let session = frame_pool.create_capture_session(item)?;
-
-        // Setup the frame arrived handler
-        let (sender, receiver) = channel();
-        let frame_arrived = FrameArrivedHandler::new({
-            let d3d_device = d3d_device.clone();
-            let d3d_context = d3d_context.clone();
-            let session = session.clone();
-            move |frame_pool, _| {
-                let frame = frame_pool.try_get_next_frame()?;
-                let surface = frame.surface()?;
-
-                let frame_texture = D3D11Texture2D::from_direct3d_surface(&surface)?;
-
-                // Make a copy of the texture
-                let mut desc = frame_texture.get_desc();
-                // Make this a staging texture
-                desc.Usage = D3D11_USAGE_STAGING;
-                desc.BindFlags = 0;
-                desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-                desc.MiscFlags = 0;
-                let copy_texture = d3d_device.create_texture_2d(&desc, None)?;
-                d3d_context.copy_resource(&copy_texture, &frame_texture);
-
-                // End the capture
-                session.close()?;
-                frame_pool.close()?;
-
-                sender.send(copy_texture).unwrap();
-
-                Ok(())
-            }
-        });
-
-        // Start the capture
-        frame_pool.frame_arrived(frame_arrived)?;
-        session.start_capture()?;
-
-        // Wait for our texture to come
-        let texture = receiver.recv().unwrap();
-        let surface = texture.to_direct3d_surface()?;
-
-        Ok(surface)
+impl Drop for CaptureSnapshot {
+    fn drop(&mut self) {
+        self.trigger_capture.send(TriggerCommand::Exit).unwrap();
     }
 }

--- a/src/win/snapshot.rs
+++ b/src/win/snapshot.rs
@@ -1,0 +1,151 @@
+use super::d3d::{D3D11Device, D3D11Texture2D};
+use crate::windows::graphics::capture::{
+    Direct3D11CaptureFramePool, GraphicsCaptureItem, GraphicsCaptureSession,
+};
+use crate::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+use crate::windows::graphics::directx::DirectXPixelFormat;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use winapi::um::d3d11::{D3D11_CPU_ACCESS_READ, D3D11_USAGE_STAGING};
+
+type FrameArrivedHandler =
+    crate::windows::foundation::TypedEventHandler<Direct3D11CaptureFramePool, winrt::Object>;
+
+pub struct CaptureSnapshot {
+    _session: GraphicsCaptureSession,
+    trigger_capture: Sender<()>,
+    image_data: Receiver<D3D11Texture2D>,
+}
+
+impl CaptureSnapshot {
+    pub fn create_session(
+        device: &IDirect3DDevice,
+        item: &GraphicsCaptureItem,
+    ) -> winrt::Result<CaptureSnapshot> {
+        let d3d_device = D3D11Device::from_direct3d_device(device)?;
+        let d3d_context = d3d_device.get_immediate_context();
+        let item_size = item.size()?;
+
+        // Initialize the capture
+        let frame_pool = Direct3D11CaptureFramePool::create_free_threaded(
+            device,
+            DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            1,
+            &item_size,
+        )?;
+        let session = frame_pool.create_capture_session(item)?;
+
+        let (trigger_capture_sender, trigger_capture_receiver) = channel();
+        let (image_data_sender, image_data_receiver) = channel();
+        let frame_arrived = FrameArrivedHandler::new({
+            let d3d_device = d3d_device.clone();
+            let d3d_context = d3d_context.clone();
+            let session = session.clone();
+            move |frame_pool, _| {
+                if let Ok(()) = trigger_capture_receiver.recv() {
+                    let frame = frame_pool.try_get_next_frame()?;
+                    let surface = frame.surface()?;
+
+                    let frame_texture = D3D11Texture2D::from_direct3d_surface(&surface)?;
+
+                    // Make a copy of the texture
+                    let mut desc = frame_texture.get_desc();
+                    // Make this a staging texture
+                    desc.Usage = D3D11_USAGE_STAGING;
+                    desc.BindFlags = 0;
+                    desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+                    desc.MiscFlags = 0;
+                    let copy_texture = d3d_device.create_texture_2d(&desc, None)?;
+                    d3d_context.copy_resource(&copy_texture, &frame_texture);
+
+                    // // End the capture
+                    // session.close()?;
+                    // frame_pool.close()?;
+
+                    image_data_sender.send(copy_texture).unwrap();
+                }
+                Ok(())
+            }
+        });
+
+        // Start the capture
+        frame_pool.frame_arrived(frame_arrived)?;
+        session.start_capture()?;
+        Ok(CaptureSnapshot {
+            _session: session,
+            image_data: image_data_receiver,
+            trigger_capture: trigger_capture_sender,
+        })
+    }
+
+    pub fn take_session(&self) -> winrt::Result<IDirect3DSurface> {
+        self.trigger_capture.send(()).unwrap();
+        // Wait for our texture to come
+        let texture = self.image_data.recv().unwrap();
+        let surface = texture.to_direct3d_surface()?;
+
+        Ok(surface)
+    }
+
+    // TODO: Allow to create non-staging textures
+    // TODO: Allow specifying pixel format
+    // TODO: Async?
+    pub fn take(
+        device: &IDirect3DDevice,
+        item: &GraphicsCaptureItem,
+    ) -> winrt::Result<IDirect3DSurface> {
+        let d3d_device = D3D11Device::from_direct3d_device(device)?;
+        let d3d_context = d3d_device.get_immediate_context();
+        let item_size = item.size()?;
+
+        // Initialize the capture
+        let frame_pool = Direct3D11CaptureFramePool::create_free_threaded(
+            device,
+            DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            1,
+            &item_size,
+        )?;
+        let session = frame_pool.create_capture_session(item)?;
+
+        // Setup the frame arrived handler
+        let (sender, receiver) = channel();
+        let frame_arrived = FrameArrivedHandler::new({
+            let d3d_device = d3d_device.clone();
+            let d3d_context = d3d_context.clone();
+            let session = session.clone();
+            move |frame_pool, _| {
+                let frame = frame_pool.try_get_next_frame()?;
+                let surface = frame.surface()?;
+
+                let frame_texture = D3D11Texture2D::from_direct3d_surface(&surface)?;
+
+                // Make a copy of the texture
+                let mut desc = frame_texture.get_desc();
+                // Make this a staging texture
+                desc.Usage = D3D11_USAGE_STAGING;
+                desc.BindFlags = 0;
+                desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+                desc.MiscFlags = 0;
+                let copy_texture = d3d_device.create_texture_2d(&desc, None)?;
+                d3d_context.copy_resource(&copy_texture, &frame_texture);
+
+                // End the capture
+                session.close()?;
+                frame_pool.close()?;
+
+                sender.send(copy_texture).unwrap();
+
+                Ok(())
+            }
+        });
+
+        // Start the capture
+        frame_pool.frame_arrived(frame_arrived)?;
+        session.start_capture()?;
+
+        // Wait for our texture to come
+        let texture = receiver.recv().unwrap();
+        let surface = texture.to_direct3d_surface()?;
+
+        Ok(surface)
+    }
+}

--- a/src/win/snapshot.rs
+++ b/src/win/snapshot.rs
@@ -2,7 +2,7 @@ use super::d3d::{D3D11Device, D3D11Texture2D};
 use crate::win::windows::graphics::capture::{
     Direct3D11CaptureFramePool, GraphicsCaptureItem, GraphicsCaptureSession,
 };
-use crate::win::windows::graphics::directx::direct3d11::{IDirect3DDevice, IDirect3DSurface};
+use crate::win::windows::graphics::directx::direct3d11::IDirect3DDevice;
 use crate::win::windows::graphics::directx::DirectXPixelFormat;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use winapi::um::d3d11::{D3D11_CPU_ACCESS_READ, D3D11_USAGE_STAGING};

--- a/src/win/snapshot.rs
+++ b/src/win/snapshot.rs
@@ -92,6 +92,9 @@ impl CaptureSnapshot {
             }
         });
 
+        // Prevent the cursor from being visible in the recorded image
+        session.set_is_cursor_capture_enabled(true)?;
+
         // Start the capture
         frame_pool.frame_arrived(frame_arrived)?;
         session.start_capture()?;


### PR DESCRIPTION
This is a first cut of Windows support for t-rec. It still requires imagemagick, but it appears to work.

It uses the `wgc-rust-demo` program to capture frames using Windows.Graphics.Capture. This enables capture of a variety of window types, and places a yellow border around the target window.

Current issues with this:

* It will default to capturing the window in front, rather than the window that was launched. This can be surprising if you alt-tab.
* It still tries to run `/bin/sh` by default. It's unclear what the default shell should be (cmd? powershell? pwsh?)
* It doesn't know anything about menubars, though with `Windows.Graphics.Capture` this appears to not be an issue since window decorations aren't captured to begin with.

![t-rec_5](https://user-images.githubusercontent.com/238325/103436526-7abcee80-4c57-11eb-8f5d-d89bdd2c0ec5.gif)
