### PR TITLE
feat(shell): refactor the default shell to be platform specific

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -7,6 +7,8 @@ pub fn setup() -> Result<Box<dyn PlatformApi>> {
     Ok(Box::new(X11Api::new()?))
 }
 
+pub const DEFAULT_SHELL: &str = "/bin/sh";
+
 #[derive(Debug)]
 pub struct Margin {
     pub top: u16,

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -8,6 +8,8 @@ use crate::{ImageOnHeap, Result, WindowList};
 use screenshot::capture_window_screenshot;
 use window_id::window_list;
 
+pub const DEFAULT_SHELL: &str = "/bin/sh";
+
 pub fn setup() -> Result<Box<dyn PlatformApi>> {
     Ok(Box::new(QuartzApi))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<()> {
         if args.is_present("program") {
             args.value_of("program").unwrap().to_owned()
         } else {
-            let default = "/bin/sh".to_owned();
+            let default = DEFAULT_SHELL.to_owned();
             env::var("SHELL").unwrap_or(default)
         }
     };

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,5 +1,7 @@
 use crate::{ImageOnHeap, WindowList};
 
+pub const DEFAULT_SHELL: &str = "cmd.exe";
+
 pub fn window_list() -> anyhow::Result<WindowList> {
     unimplemented!("there is only an impl for MacOS")
 }


### PR DESCRIPTION
 - this would allow to have a windows specific different shell than `/bin/sh` as mentioned in PR #34 