### PR TITLE
fix(effects): thread count went wild, now it's limited by rayon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 🎯 [Unreleased]
+
+## [0.4.1] - 2021-01-03
 ### Added
 - Snap support on it's way to [snapcraft.io](https://snapcraft.io/t-rec) [pull/25], thanks to [@popey](https://github.com/popey)
 ### Fixed
 - reduced crate size from 4.8MB to 34kB [pull/32], thanks to [@Byron](https://github.com/Byron)
 - fixed a panic when the active window cannot be identified on Linux [pull/31] / [issue/30]
 - fixed `t-rec -l` did not show any window names on Linux [pull/31]
+- fixed system freeze on "Applying Effects" caused by too many threads [issue/29]
 
 [pull/32]: https://github.com/sassman/t-rec-rs/pull/32
 [pull/31]: https://github.com/sassman/t-rec-rs/pull/31
-[issue/30]: https://github.com/sassman/t-rec-rs/issues/30
 [pull/25]: https://github.com/sassman/t-rec-rs/pull/25
+[issue/30]: https://github.com/sassman/t-rec-rs/issues/30
+[issue/29]: https://github.com/sassman/t-rec-rs/issues/29
 
 ## [0.4.0] - 2020-12-27
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "atty"
@@ -274,11 +274,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -630,7 +630,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "t-rec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -643,6 +643,7 @@ dependencies = [
  "log",
  "objc-foundation",
  "objc_id",
+ "rayon",
  "tempfile",
  "x11rb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "t-rec"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Sven Assmann <sven.assmann.it@gmail.com>"]
 edition = "2018"
 license = "GPL-3.0-only"
@@ -20,10 +20,11 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 clap = "2.33.3"
-image = "0.23.12"
+image = { version = "0.23.12", features = ["tga"] }
 anyhow = "1.0.35"
 tempfile = "3.1.0"
 gif = "0.11"
+rayon = "1.5.0"
 log = "0.4.11"
 env_logger = "0.8.2"
 #image-convert = "0.10"
@@ -31,12 +32,12 @@ env_logger = "0.8.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc_id = "0.1.1"
 objc-foundation = "0.1.1"
-core-graphics = "0.22"
-core-foundation = "0.9"
-core-foundation-sys = "0.8"
+core-graphics = "0.22.2"
+core-foundation = "0.9.1"
+core-foundation-sys = "0.8.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-x11rb = "0.7"
+x11rb = "0.7.0"
 
 [features]
 test_against_real_display = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,11 @@ fn capture_thread(
             // let's track now the duration as idle
             idle_duration = idle_duration.add(now.duration_since(last_now));
         } else {
-            save_frame(&image, tc, tempdir.lock().unwrap().borrow(), file_name_for)?;
+            if let Err(e) = save_frame(&image, tc, tempdir.lock().unwrap().borrow(), file_name_for)
+            {
+                eprintln!("{}", &e);
+                return Err(e);
+            }
             time_codes.lock().unwrap().push(tc);
             last_frame = Some(image);
             identical_frames = 0;


### PR DESCRIPTION
This PR limits the thread count used for the effects' application by delegating the optimal thread count determination to rayon. That fixes #29.

Additionally, there are:
- pinned version numbers to minor versions
- limit the image crate features to only `tga` that is the only needed
- changelog additions
- preparation for the next patch release