### PR TITLE
Add quiet (-q|--quiet) mode to suppress Ctrl+D banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 🎯 [Unreleased]
+### Added
+- Quiet (-q|--quiet) mode to suppress Ctrl+D banner: 'Press Ctrl+D to end recording' [pull/39]
 
 ## [0.4.2] - 2021-01-04
 ### Added

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,13 @@ pub fn launch<'a>() -> ArgMatches<'a> {
                 .required(false)
                 .help("Enable verbose insights for the curious.")
         )
+        .arg(Arg::with_name("quiet")
+                .takes_value(false)
+                .short("q")
+                .long("quiet")
+                .required(false)
+                .help("Quiet mode, suppresses the banner: 'Press Ctrl+D to end recording'")
+        )
         .arg(
             Arg::with_name("decor")
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,11 @@ fn main() -> Result<()> {
             println!("Recording window id: {}", win_id);
         }
     }
-    println!("Press Ctrl+D to end recording");
+    if args.is_present("quiet") {
+        println!();
+    } else {
+        println!("Press Ctrl+D to end recording");
+    }
     thread::sleep(Duration::from_millis(1250));
     clear_screen();
 


### PR DESCRIPTION
Previously, all recordings would display, "Press Ctrl+D to end
recording".  This is helpful (& even desirable) on first usage.
However, it is annoying to have the banner in all the recordings.

This adds the ability to add -q|--quiet, which suppresses the banner
making cleaner recordings.  (An empty string is outputted as the
application needs there to be something to begin recording)

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>