### PR TITLE
feat(#105): add support configuring output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: build .deb file
-        uses: sassman/rust-deb-builder@v1.57.0
+        uses: sassman/rust-deb-builder@v1
       - name: Archive deb artifact
         uses: actions/upload-artifact@v2
         with:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,6 +103,15 @@ pub fn launch() -> ArgMatches {
                 .help("to specify the pause time at the start of the animation, that time the gif will show the first frame"),
         )
         .arg(
+            Arg::new("file")
+                .takes_value(true)
+                .required(false)
+                .short('o')
+                .long("output")
+                .default_value("t-rec")
+                .help("to specify the output file (without extension)"),
+        )
+        .arg(
             Arg::new("program")
                 .value_name("shell or program to launch")
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::generators::{check_for_gif, check_for_mp4, generate_gif, generate_mp4
 use crate::tips::show_tip;
 
 use crate::capture::capture_thread;
-use crate::utils::{sub_shell_thread, target_file};
+use crate::utils::{sub_shell_thread, target_file, DEFAULT_EXT, MOVIE_EXT};
 use anyhow::{bail, Context};
 use clap::ArgMatches;
 use image::FlatSamples;
@@ -158,7 +158,7 @@ fn main() -> Result<()> {
         )
     }
 
-    let target = target_file();
+    let target = target_file(args.value_of("file").unwrap());
     let mut time = Duration::default();
 
     if should_generate_gif {
@@ -166,7 +166,7 @@ fn main() -> Result<()> {
             generate_gif(
                 &time_codes.lock().unwrap(),
                 tempdir.lock().unwrap().borrow(),
-                &format!("{}.{}", target, "gif"),
+                &format!("{}.{}", target, DEFAULT_EXT),
                 start_delay,
                 end_delay
             )?;
@@ -178,7 +178,7 @@ fn main() -> Result<()> {
             generate_mp4(
                 &time_codes.lock().unwrap(),
                 tempdir.lock().unwrap().borrow(),
-                &format!("{}.{}", target, "mp4"),
+                &format!("{}.{}", target, MOVIE_EXT),
             )?;
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use std::ffi::OsStr;
 use std::process::{Command, ExitStatus};
 
+pub const DEFAULT_EXT: &str = "gif";
+pub const MOVIE_EXT: &str = "mp4";
+
 /// encapsulate the file naming convention
 pub fn file_name_for(tc: &u128, ext: &str) -> String {
     format!("t-rec-frame-{:09}.{}", tc, ext)
@@ -20,17 +23,16 @@ pub fn sub_shell_thread<T: AsRef<OsStr> + Clone>(program: T) -> Result<ExitStatu
 /// returns a new filename that does not yet exists.
 /// Note: returns without extension, but checks with extension
 /// like `t-rec` or `t-rec_1`
-pub fn target_file() -> String {
+pub fn target_file(basename: impl AsRef<str>) -> String {
+    let basename = basename.as_ref();
     let mut suffix = "".to_string();
-    let default_ext = "gif";
-    let movie_ext = "mp4";
     let mut i = 0;
-    while std::path::Path::new(format!("t-rec{}.{}", suffix, default_ext).as_str()).exists()
-        || std::path::Path::new(format!("t-rec{}.{}", suffix, movie_ext).as_str()).exists()
+    while std::path::Path::new(format!("{basename}{suffix}.{DEFAULT_EXT}").as_str()).exists()
+        || std::path::Path::new(format!("{basename}{suffix}.{MOVIE_EXT}").as_str()).exists()
     {
         i += 1;
         suffix = format!("_{}", i).to_string();
     }
 
-    format!("t-rec{}", suffix)
+    format!("{basename}{suffix}")
 }


### PR DESCRIPTION
- fixes #105 
- introduce `-o | --output` argument that accepts the file basename without any extension 
- the logic with checking for file existence and adding incrementing numbers remains as is