### PR TITLE
feat: add --idle-pause <time> parameter for a minimum time before idle frame optimization starts to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Options:
                                   the gif will show the last frame
   -s, --start-pause <s | ms | m>  to specify the pause time at the start of the animation, that time
                                   the gif will show the first frame
+  -i, --idle-pause <s | ms | m>   to specify the minimum pause for idle frames, that time the
+                                  animation will show unchanged content
   -o, --output <file>             to specify the output file (without extension) [default: t-rec]
   -h, --help                      Print help
   -V, --version                   Print version
@@ -175,6 +177,13 @@ Options:
 If you are not happy with the idle detection and optimization, you can disable it with the `-n` or `--natural` parameter.
 By doing so, you would get the very natural timeline of typing and recording as you do it. 
 In this case there will be no optimizations performed.
+
+Alternatively, you can show some idle time before optimization kicks in with the `--idle-pause` parameter.
+This gives viewers time to read the text on screen before the animation jumps to the next change:
+```sh
+t-rec --idle-pause 1s        # Show 1 second of unchanged content before optimization
+t-rec --idle-pause 500ms     # Show 500ms of idle time
+```
 
 ### Enable shadow border decor
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -21,12 +21,16 @@ pub fn capture_thread(
     time_codes: Arc<Mutex<Vec<u128>>>,
     tempdir: Arc<Mutex<TempDir>>,
     force_natural: bool,
+    idle_pause: Option<Duration>,
 ) -> Result<()> {
-    let duration = Duration::from_millis(250);
+    #[cfg(test)]
+    let duration = Duration::from_millis(10); // Fast for testing
+    #[cfg(not(test))]
+    let duration = Duration::from_millis(250); // Production speed
     let start = Instant::now();
     let mut idle_duration = Duration::from_millis(0);
+    let mut current_idle_period = Duration::from_millis(0);
     let mut last_frame: Option<ImageOnHeap> = None;
-    let mut identical_frames = 0;
     let mut last_now = Instant::now();
     loop {
         // blocks for a timeout
@@ -37,37 +41,45 @@ pub fn capture_thread(
         let effective_now = now.sub(idle_duration);
         let tc = effective_now.saturating_duration_since(start).as_millis();
         let image = api.capture_window_screenshot(win_id)?;
-        if !force_natural {
-            if last_frame.is_some()
-                && image
-                    .samples
-                    .as_slice()
-                    .eq(last_frame.as_ref().unwrap().samples.as_slice())
-            {
-                identical_frames += 1;
-            } else {
-                identical_frames = 0;
-            }
-        }
-
-        if identical_frames > 0 {
-            // let's track now the duration as idle
-            idle_duration = idle_duration.add(now.duration_since(last_now));
+        let frame_duration = now.duration_since(last_now);
+        
+        // Check if frame is unchanged from previous (only when not in natural mode)
+        let frame_unchanged = !force_natural 
+            && last_frame.as_ref()
+                .map(|last| image.samples.as_slice() == last.samples.as_slice())
+                .unwrap_or(false);
+        
+        if frame_unchanged {
+            current_idle_period = current_idle_period.add(frame_duration);
         } else {
-            if let Err(e) = save_frame(&image, tc, tempdir.lock().unwrap().borrow(), file_name_for)
-            {
+            current_idle_period = Duration::from_millis(0);
+        }
+        
+        // Determine if we should save this frame
+        let should_save_frame = !frame_unchanged || idle_pause
+            .map(|min_idle| current_idle_period < min_idle)
+            .unwrap_or(false);
+        
+        if should_save_frame {
+            // Save frame and update state
+            if let Err(e) = save_frame(&image, tc, tempdir.lock().unwrap().borrow(), file_name_for) {
                 eprintln!("{}", &e);
                 return Err(e);
             }
             time_codes.lock().unwrap().push(tc);
+            
+            // Update last_frame to current frame for next iteration's comparison
             last_frame = Some(image);
-            identical_frames = 0;
+        } else {
+            // Skip this idle frame and track the skipped time
+            idle_duration = idle_duration.add(frame_duration);
         }
         last_now = now;
     }
 
     Ok(())
 }
+
 
 /// saves a frame as a tga file
 pub fn save_frame(
@@ -84,4 +96,74 @@ pub fn save_frame(
         image.color_hint.unwrap_or(Rgba8),
     )
     .context("Cannot save frame")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_idle_pause() -> crate::Result<()> {
+        // Mock API that cycles through predefined frame data for testing
+        struct TestApi {
+            frames: Vec<Vec<u8>>,
+            index: std::cell::Cell<usize>,
+        }
+
+        impl crate::PlatformApi for TestApi {
+            fn capture_window_screenshot(&self, _: crate::WindowId) -> crate::Result<crate::ImageOnHeap> {
+                let i = self.index.get();
+                self.index.set(i + 1);
+                // Return 1x1 RGBA pixel data cycling through frames
+                Ok(Box::new(image::FlatSamples {
+                    samples: self.frames[i % self.frames.len()].clone(),
+                    layout: image::flat::SampleLayout::row_major_packed(4, 1, 1),
+                    color_hint: Some(image::ColorType::Rgba8)
+                }))
+            }
+            fn calibrate(&mut self, _: crate::WindowId) -> crate::Result<()> { Ok(()) }
+            fn window_list(&self) -> crate::Result<crate::WindowList> { Ok(vec![]) }
+            fn get_active_window(&self) -> crate::Result<crate::WindowId> { Ok(0) }
+        }
+
+        // Test cases: (force_natural, frame_data, idle_pause, min_saves, description)
+        // Each vec![Nu8; 4] represents a 1x1 RGBA pixel with value N for all channels
+        let cases = [
+            (true, vec![vec![1u8; 4]; 3], None, 3, "natural mode saves all frames"),
+            (false, vec![vec![1u8; 4]], None, 1, "first frame always saved"),
+            (false, vec![vec![1u8; 4], vec![2u8; 4], vec![3u8; 4]], None, 3, "different frames saved"),
+            (false, vec![vec![1u8; 4]; 3], None, 1, "identical frames skipped"),
+            (false, vec![vec![1u8; 4]; 3], Some(Duration::from_millis(500)), 2, "idle pause saves initial frames"),
+        ];
+
+        for (i, (natural, frame_data, pause, min_saves, desc)) in cases.iter().enumerate() {
+            // Create mock API with test frame data
+            let api = TestApi {
+                frames: frame_data.clone(),
+                index: Default::default(),
+            };
+
+            // Set up capture infrastructure
+            let time_codes = Arc::new(Mutex::new(Vec::new()));
+            let tempdir = Arc::new(Mutex::new(TempDir::new()?));
+            let (tx, rx) = mpsc::channel();
+
+            // Spawn thread to stop recording after enough time for captures (fast in test mode)
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(50));
+                let _ = tx.send(());
+            });
+
+            // Run the actual capture_thread function being tested
+            capture_thread(&rx, api, 0, time_codes.clone(), tempdir, *natural, *pause)?;
+            
+            // Verify the expected number of frames were saved
+            let saved = time_codes.lock().unwrap().len();
+            assert!(saved >= *min_saves, "Case {}: {} - expected ≥{} saves, got {}", i + 1, desc, min_saves, saved);
+        }
+        Ok(())
+    }
+
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,6 +104,15 @@ pub fn launch() -> ArgMatches {
                 .help("to specify the pause time at the start of the animation, that time the gif will show the first frame"),
         )
         .arg(
+            Arg::new("idle-pause")
+                .value_parser(NonEmptyStringValueParser::new())
+                .value_name("s | ms | m")
+                .required(false)
+                .short('i')
+                .long("idle-pause")
+                .help("to specify the minimum pause for idle frames, that time the animation will show unchanged content"),
+        )
+        .arg(
             Arg::new("file")
                 .value_parser(NonEmptyStringValueParser::new())
                 .required(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,9 +81,10 @@ fn main() -> Result<()> {
     let force_natural = args.get_flag("natural-mode");
     let should_generate_gif = !args.get_flag("video-only");
     let should_generate_video = args.get_flag("video") || args.get_flag("video-only");
-    let (start_delay, end_delay) = (
+    let (start_delay, end_delay, idle_pause) = (
         parse_delay(args.get_one::<String>("start-pause"), "start-pause")?,
         parse_delay(args.get_one::<String>("end-pause"), "end-pause")?,
+        parse_delay(args.get_one::<String>("idle-pause"), "idle-pause")?,
     );
 
     if should_generate_gif {
@@ -103,7 +104,7 @@ fn main() -> Result<()> {
         let tempdir = tempdir.clone();
         let time_codes = time_codes.clone();
         thread::spawn(move || -> Result<()> {
-            capture_thread(&rx, api, win_id, time_codes, tempdir, force_natural)
+            capture_thread(&rx, api, win_id, time_codes, tempdir, force_natural, idle_pause)
         })
     };
     let interact = thread::spawn(move || -> Result<()> { sub_shell_thread(&program).map(|_| ()) });


### PR DESCRIPTION
# Add `--idle-pause <time>` parameter for a minimum time before idle frame optimization starts to improve readability

This PR adds the `--idle-pause` parameter to t-rec's existing idle optimization. This parameter
allows users to specify a minimum duration for idle frames to be displayed before optimization
begins.

## Benefits

The key benefit is giving viewers sufficient time to read the text on screen before the animation
advances to the next change. This makes demos easier to read and follow, particularly for:

- **Tutorials**: Viewers can read command output at their own pace
- **Documentation**: Step-by-step guides become more accessible
- **Educational Content**: Learners have time to process information

## Implementation Details

### CLI Interface
- Added `-i, --idle-pause <s | ms | m>` parameter
- Uses the existing `parse_delay` function for duration parsing
- Follows the same pattern as `--start-pause` and `--end-pause`

### Core Logic Changes
- Replaced the `identical_frames` counter with `current_idle_period` duration tracking
- Frames are saved when `current_idle_period < idle_pause` threshold is met
- Refactored frame comparison logic for cleaner boolean expressions
- Added `idle_pause: Option<Duration>` parameter to `capture_thread`

### Testing
- Added integration test covering five scenarios: natural mode, first frame, different frames,
identical frames, and idle pause behavior
- Uses conditional compilation for faster test execution (10ms vs 250ms intervals)
- Uses mock API with minimal 1x1 RGBA pixel data for efficiency

## Usage Examples

```bash
# Show 1 second of unchanged content before optimization
t-rec --idle-pause 1s

# Show 500ms of idle time
t-rec --idle-pause 500ms

# Original behavior (no idle pause)
t-rec
````

## Backward Compatibility

When `--idle-pause` is not specified, behavior remains identical to previous versions.

## Files Modified

  - `src/cli.rs`: Added CLI parameter definition
  - `src/main.rs`: Parses idle-pause argument and passes it to capture thread
  - `src/capture.rs`: Implements duration-based idle detection and test coverage
  - `README.md`: Documents parameter and provides usage examples

This enhancement extends t-rec's efficient idle optimization with user-configurable timing control,
enabling recordings that give viewers adequate reading time.