### PR TITLE
feat: native image ops with parallelized Gaussian blur #321

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+# open the report at `target/criterion/report/index.html`
+"b:run" = "bench -p t-rec --bench decors_benchmark -- --sample-size 10 --warm-up-time 1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +135,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -186,6 +231,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +315,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dialoguer"
@@ -386,6 +473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +494,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
@@ -429,10 +533,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
@@ -456,6 +586,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -658,6 +798,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +839,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -849,6 +1023,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +1071,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -968,6 +1170,7 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
+ "criterion",
  "crossterm",
  "dialoguer",
  "dirs",
@@ -1005,22 +1208,32 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1090,6 +1303,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1325,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1119,6 +1397,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1244,6 +1531,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "zerocopy"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
 name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,9 +1564,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c86acb70a85b2c16f071f171847d1945e8f44812630463cd14ec83900ad01c"
+checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +40,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -69,21 +75,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block2"
@@ -95,16 +101,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
+name = "bumpalo"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -119,10 +137,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.6.1"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -130,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -141,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -153,24 +198,25 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
+ "once_cell",
  "unicode-width",
  "windows-sys",
 ]
@@ -191,6 +237,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -244,6 +326,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "derive_more"
@@ -300,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags",
  "objc2",
@@ -319,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -331,9 +419,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
@@ -341,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -370,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -385,19 +473,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gethostname"
@@ -422,31 +504,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
- "wasip3",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.5"
+name = "half"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "foldhash",
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -455,22 +538,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -483,14 +566,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -500,16 +592,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itoa"
-version = "1.0.18"
+name = "itertools"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
  "log",
@@ -520,13 +621,23 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -536,12 +647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,18 +654,19 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
+ "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -585,9 +691,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -601,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -613,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -644,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -723,15 +829,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "option-ext"
@@ -764,15 +876,43 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
-version = "0.18.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -783,27 +923,17 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -817,30 +947,33 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "6.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -878,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -890,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -901,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc_version"
@@ -916,15 +1049,30 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -971,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -1030,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simplerand"
@@ -1051,9 +1199,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1066,6 +1214,7 @@ version = "0.9.0-preview1"
 dependencies = [
  "anyhow",
  "clap",
+ "criterion",
  "crossterm",
  "dialoguer",
  "dirs",
@@ -1092,12 +1241,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1124,10 +1273,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
+name = "tinytemplate"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1173,9 +1332,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1190,16 +1349,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1209,54 +1372,66 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+name = "wasm-bindgen"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
+name = "wasm-bindgen-macro"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
- "leb128fmt",
- "wasmparser",
+ "quote",
+ "wasm-bindgen-macro-support",
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.244.0"
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
+name = "wasm-bindgen-shared"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1283,6 +1458,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1509,94 +1693,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "x11rb"
@@ -1616,10 +1712,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
-name = "zmij"
-version = "1.0.21"
+name = "zerocopy"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zune-core"
@@ -1629,9 +1745,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.15"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
 dependencies = [
  "zune-core",
 ]

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -68,6 +68,9 @@ name = "t-rec"
 path = "src/main.rs"
 required-features = ["cli"]
 
+# Experimental: Use native Rust image operations instead of ImageMagick
+x-native-imgops = []
+
 [package.metadata.deb]
 section = "x11"
 depends = "imagemagick"

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -71,6 +71,13 @@ required-features = ["cli"]
 # Experimental: Use native Rust image operations instead of ImageMagick
 x-native-imgops = []
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "decors_benchmark"
+harness = false
+
 [package.metadata.deb]
 section = "x11"
 depends = "imagemagick"

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -63,13 +63,13 @@ e2e_tests = []
 # Library users get a minimal lib without CLI-only code by default.
 cli = []
 
+# Experimental: Use native Rust image operations instead of ImageMagick
+x-native-imgops = []
+
 [[bin]]
 name = "t-rec"
 path = "src/main.rs"
 required-features = ["cli"]
-
-# Experimental: Use native Rust image operations instead of ImageMagick
-x-native-imgops = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -84,6 +84,13 @@ required-features = ["cli"]
 # Experimental: Use native Rust image operations instead of ImageMagick
 x-native-imgops = []
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "decors_benchmark"
+harness = false
+
 [package.metadata.deb]
 section = "x11"
 depends = "imagemagick"

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -76,13 +76,13 @@ e2e_tests = []
 # Library users get a minimal lib without CLI-only code by default.
 cli = []
 
+# Experimental: Use native Rust image operations instead of ImageMagick
+x-native-imgops = []
+
 [[bin]]
 name = "t-rec"
 path = "src/main.rs"
 required-features = ["cli"]
-
-# Experimental: Use native Rust image operations instead of ImageMagick
-x-native-imgops = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -81,6 +81,9 @@ name = "t-rec"
 path = "src/main.rs"
 required-features = ["cli"]
 
+# Experimental: Use native Rust image operations instead of ImageMagick
+x-native-imgops = []
+
 [package.metadata.deb]
 section = "x11"
 depends = "imagemagick"

--- a/crates/t-rec/benches/README.md
+++ b/crates/t-rec/benches/README.md
@@ -1,0 +1,17 @@
+# Benchmarks
+
+## Decors Benchmark
+
+Compares native Rust image operations vs ImageMagick for corner and shadow effects.
+
+Using the cargo alias (runs ImageMagick-only benchmarks):
+
+```sh
+cargo b:run
+```
+
+With the native imgops feature enabled (compares both implementations):
+
+```sh
+cargo bench -p t-rec --features x-native-imgops --bench decors_benchmark -- --sample-size 10 --warm-up-time 1
+```

--- a/crates/t-rec/benches/decors_benchmark.rs
+++ b/crates/t-rec/benches/decors_benchmark.rs
@@ -21,7 +21,7 @@ fn bench_corner_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("native_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::decors::apply_corner_to_file_native(black_box(&path)).unwrap();
+                t_rec::core::decors::apply_corner_to_file_native(black_box(&path)).unwrap();
             });
         });
 
@@ -30,7 +30,7 @@ fn bench_corner_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("magick_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::decors::apply_corner_to_file_imagemagick(black_box(&path)).unwrap();
+                t_rec::core::decors::apply_corner_to_file_imagemagick(black_box(&path)).unwrap();
             });
         });
     }
@@ -50,7 +50,7 @@ fn bench_shadow_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("native_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::decors::apply_shadow_to_file_native(black_box(&path), "white").unwrap();
+                t_rec::core::decors::apply_shadow_to_file_native(black_box(&path), "white").unwrap();
             });
         });
 
@@ -59,7 +59,7 @@ fn bench_shadow_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("magick_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::decors::apply_shadow_to_file_imagemagick(black_box(&path), "white").unwrap();
+                t_rec::core::decors::apply_shadow_to_file_imagemagick(black_box(&path), "white").unwrap();
             });
         });
     }

--- a/crates/t-rec/benches/decors_benchmark.rs
+++ b/crates/t-rec/benches/decors_benchmark.rs
@@ -50,7 +50,8 @@ fn bench_shadow_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("native_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::core::decors::apply_shadow_to_file_native(black_box(&path), "white").unwrap();
+                t_rec::core::decors::apply_shadow_to_file_native(black_box(&path), "white")
+                    .unwrap();
             });
         });
 
@@ -59,7 +60,8 @@ fn bench_shadow_effects(c: &mut Criterion) {
             let path = temp_dir.path().join(format!("magick_{}.bmp", size));
             b.iter(|| {
                 create_test_image(&path, size, size);
-                t_rec::core::decors::apply_shadow_to_file_imagemagick(black_box(&path), "white").unwrap();
+                t_rec::core::decors::apply_shadow_to_file_imagemagick(black_box(&path), "white")
+                    .unwrap();
             });
         });
     }

--- a/crates/t-rec/benches/decors_benchmark.rs
+++ b/crates/t-rec/benches/decors_benchmark.rs
@@ -1,0 +1,71 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use image::{ColorType, Rgba, RgbaImage};
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Create a test image of given size and save it to the specified path
+fn create_test_image(path: &Path, width: u32, height: u32) {
+    let img = RgbaImage::from_pixel(width, height, Rgba([255, 0, 0, 255]));
+    image::save_buffer(path, img.as_raw(), width, height, ColorType::Rgba8).unwrap();
+}
+
+fn bench_corner_effects(c: &mut Criterion) {
+    let mut group = c.benchmark_group("corner_effects");
+
+    // Test different image sizes
+    for size in [100, 400, 800].iter() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Benchmark native implementation
+        group.bench_with_input(BenchmarkId::new("native", size), size, |b, &size| {
+            let path = temp_dir.path().join(format!("native_{}.bmp", size));
+            b.iter(|| {
+                create_test_image(&path, size, size);
+                t_rec::decors::apply_corner_to_file_native(black_box(&path)).unwrap();
+            });
+        });
+
+        // Benchmark ImageMagick implementation
+        group.bench_with_input(BenchmarkId::new("imagemagick", size), size, |b, &size| {
+            let path = temp_dir.path().join(format!("magick_{}.bmp", size));
+            b.iter(|| {
+                create_test_image(&path, size, size);
+                t_rec::decors::apply_corner_to_file_imagemagick(black_box(&path)).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_shadow_effects(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shadow_effects");
+
+    // Test different image sizes
+    for size in [100, 400, 800].iter() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Benchmark native implementation
+        group.bench_with_input(BenchmarkId::new("native", size), size, |b, &size| {
+            let path = temp_dir.path().join(format!("native_{}.bmp", size));
+            b.iter(|| {
+                create_test_image(&path, size, size);
+                t_rec::decors::apply_shadow_to_file_native(black_box(&path), "white").unwrap();
+            });
+        });
+
+        // Benchmark ImageMagick implementation
+        group.bench_with_input(BenchmarkId::new("imagemagick", size), size, |b, &size| {
+            let path = temp_dir.path().join(format!("magick_{}.bmp", size));
+            b.iter(|| {
+                create_test_image(&path, size, size);
+                t_rec::decors::apply_shadow_to_file_imagemagick(black_box(&path), "white").unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_corner_effects, bench_shadow_effects);
+criterion_main!(benches);

--- a/crates/t-rec/examples/profile_shadow.rs
+++ b/crates/t-rec/examples/profile_shadow.rs
@@ -1,5 +1,5 @@
 //! Profiling helper for shadow effect
-//! Run with: cargo flamegraph --example profile_shadow -p t-rec
+//! Run with: cargo flamegraph --example profile_shadow -p t-rec --features x-native-imgops
 
 use image::{ColorType, Rgba, RgbaImage};
 use tempfile::TempDir;
@@ -14,7 +14,7 @@ fn main() {
     // Run multiple iterations for better sampling
     for i in 0..50 {
         image::save_buffer(&path, img.as_raw(), 400, 400, ColorType::Rgba8).unwrap();
-        t_rec::decors::apply_shadow_to_file_native(&path, "white").unwrap();
+        t_rec::core::decors::apply_shadow_to_file_native(&path, "white").unwrap();
         if i % 10 == 0 {
             eprintln!("Iteration {}/50", i);
         }

--- a/crates/t-rec/examples/profile_shadow.rs
+++ b/crates/t-rec/examples/profile_shadow.rs
@@ -1,0 +1,24 @@
+//! Profiling helper for shadow effect
+//! Run with: cargo flamegraph --example profile_shadow -p t-rec
+
+use image::{ColorType, Rgba, RgbaImage};
+use tempfile::TempDir;
+
+fn main() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("test.bmp");
+
+    // Use 400x400 as representative size
+    let img = RgbaImage::from_pixel(400, 400, Rgba([255, 0, 0, 255]));
+
+    // Run multiple iterations for better sampling
+    for i in 0..50 {
+        image::save_buffer(&path, img.as_raw(), 400, 400, ColorType::Rgba8).unwrap();
+        t_rec::decors::apply_shadow_to_file_native(&path, "white").unwrap();
+        if i % 10 == 0 {
+            eprintln!("Iteration {}/50", i);
+        }
+    }
+
+    eprintln!("Done!");
+}

--- a/crates/t-rec/src/core/decors/big_sur_corner.rs
+++ b/crates/t-rec/src/core/decors/big_sur_corner.rs
@@ -215,7 +215,6 @@ mod native {
                 half_out
             );
         }
-
     }
 }
 

--- a/crates/t-rec/src/core/decors/big_sur_corner.rs
+++ b/crates/t-rec/src/core/decors/big_sur_corner.rs
@@ -1,50 +1,236 @@
 use std::path::Path;
-use std::process::Command;
-
-use anyhow::Context;
 
 use crate::core::Result;
 
-/// Apply corner radius effect to a single file.
-///
-/// Apply a corner radius decor effect via a chain of convert commands
-/// this makes sure big sur corner radius, that comes in with white color, does not mess up
-///
-/// ```sh
-/// convert t-rec-frame-000000251.bmp \
-///     \( +clone  -alpha extract \
-///         -draw 'fill black polygon 0,0 0,15 15,0 fill white circle 15,15 15,0' \
-///         \( +clone -flip \) -compose Multiply -composite \
-///         \( +clone -flop \) -compose Multiply -composite \
-///      \) -alpha off -compose CopyOpacity -composite \
-///    t-rec-frame-000000251.bmp
-/// ```
-pub fn apply_corner_to_file(file: &Path) -> Result<()> {
-    let radius = 13;
-    let e = Command::new("convert")
-        .arg(file.to_str().unwrap())
-        .arg("(")
-        .args(["+clone", "-alpha", "extract"])
-        .args([
-            "-draw",
-            &format!(
-                "fill black polygon 0,0 0,{r} {r},0 fill white circle {r},{r} {r},0",
-                r = radius
-            ),
-        ])
-        .args(["(", "+clone", "-flip", ")"])
-        .args(["-compose", "Multiply", "-composite"])
-        .args(["(", "+clone", "-flop", ")"])
-        .args(["-compose", "Multiply", "-composite"])
-        .arg(")")
-        .args(["-alpha", "off", "-compose", "CopyOpacity", "-composite"])
-        .arg(file.to_str().unwrap())
-        .output()
-        .context("Cannot apply corner decor effect")?;
+/// Corner radius in pixels (matches macOS Big Sur terminal style)
+const RADIUS: u32 = 13;
 
-    if !e.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+/// Apply corner radius effect to a single file.
+pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+    if cfg!(feature = "x-native-imgops") {
+        native::apply_corner_to_file(file)
     } else {
+        imagemagick::apply_corner_to_file(file)
+    }
+}
+
+/// Native implementation using the image crate with anti-aliased corners.
+mod native {
+    use super::*;
+    use anyhow::Context;
+    use image::{save_buffer, ColorType, Rgba};
+
+    /// Applies rounded corners with anti-aliasing by smoothly blending
+    /// the alpha channel for pixels near the corner radius edge.
+    pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+        let img = image::open(file).with_context(|| {
+            format!(
+                "Cannot open image file for corner effect: {}",
+                file.display()
+            )
+        })?;
+
+        let mut img = img.to_rgba8();
+        let (width, height) = img.dimensions();
+        let radius = RADIUS as f32;
+
+        // Apply rounded corners with anti-aliasing
+        for y in 0..height {
+            for x in 0..width {
+                let coverage = corner_coverage(x, y, width, height, radius);
+                if coverage < 1.0 {
+                    let pixel = img.get_pixel(x, y);
+                    let new_alpha = (pixel[3] as f32 * coverage) as u8;
+                    img.put_pixel(x, y, Rgba([pixel[0], pixel[1], pixel[2], new_alpha]));
+                }
+            }
+        }
+
+        save_buffer(file, img.as_raw(), width, height, ColorType::Rgba8).with_context(|| {
+            format!(
+                "Cannot save image file after corner effect: {}",
+                file.display()
+            )
+        })?;
+
         Ok(())
+    }
+
+    /// Calculate how much of a pixel is covered by the rounded corner area.
+    ///
+    /// Returns:
+    /// - 1.0 = fully inside (pixel unchanged)
+    /// - 0.0 = fully outside (pixel transparent)
+    /// - 0.0-1.0 = on the edge (smooth anti-aliased blend)
+    fn corner_coverage(x: u32, y: u32, width: u32, height: u32, radius: f32) -> f32 {
+        let x = x as f32 + 0.5; // pixel center
+        let y = y as f32 + 0.5;
+        let w = width as f32;
+        let h = height as f32;
+
+        // Top-left corner: circle center at (radius, radius)
+        if x < radius && y < radius {
+            return circle_coverage(x, y, radius, radius, radius);
+        }
+
+        // Top-right corner: circle center at (width - radius, radius)
+        if x > w - radius && y < radius {
+            return circle_coverage(x, y, w - radius, radius, radius);
+        }
+
+        // Bottom-left corner: circle center at (radius, height - radius)
+        if x < radius && y > h - radius {
+            return circle_coverage(x, y, radius, h - radius, radius);
+        }
+
+        // Bottom-right corner: circle center at (width - radius, height - radius)
+        if x > w - radius && y > h - radius {
+            return circle_coverage(x, y, w - radius, h - radius, radius);
+        }
+
+        1.0 // Not in a corner region
+    }
+
+    /// Calculate coverage for a pixel relative to a circle using signed distance.
+    fn circle_coverage(px: f32, py: f32, cx: f32, cy: f32, radius: f32) -> f32 {
+        let dx = px - cx;
+        let dy = py - cy;
+        let distance = (dx * dx + dy * dy).sqrt();
+
+        // Signed distance from circle edge (negative = inside, positive = outside)
+        let signed_distance = distance - radius;
+
+        // Smooth falloff over ~1 pixel for anti-aliasing
+        (0.5 - signed_distance).clamp(0.0, 1.0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use image::{save_buffer, ColorType, Rgba, RgbaImage};
+        use tempfile::NamedTempFile;
+
+        #[test]
+        fn test_corners_are_transparent() -> Result<()> {
+            let mut img = RgbaImage::new(30, 30);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            let (w, h) = img.dimensions();
+            save_buffer(temp.path(), img.as_raw(), w, h, ColorType::Rgba8)?;
+
+            apply_corner_to_file(temp.path())?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Corners should be fully transparent
+            assert_eq!(result.get_pixel(0, 0)[3], 0, "top-left corner");
+            assert_eq!(result.get_pixel(29, 0)[3], 0, "top-right corner");
+            assert_eq!(result.get_pixel(0, 29)[3], 0, "bottom-left corner");
+            assert_eq!(result.get_pixel(29, 29)[3], 0, "bottom-right corner");
+
+            // Center should remain opaque
+            assert_eq!(result.get_pixel(15, 15)[3], 255, "center");
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_antialiasing_produces_partial_alpha() -> Result<()> {
+            let mut img = RgbaImage::new(50, 50);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            let (w, h) = img.dimensions();
+            save_buffer(temp.path(), img.as_raw(), w, h, ColorType::Rgba8)?;
+
+            apply_corner_to_file(temp.path())?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Find a pixel on the edge that should have partial alpha
+            // At radius=13, corner center is at (13, 13)
+            // For y=1 (center 1.5), distance to circle edge is at x ≈ 7
+            // Check multiple pixels along the edge to find one with partial alpha
+            let mut found_partial = false;
+            for x in 0..13u32 {
+                for y in 0..13u32 {
+                    let alpha = result.get_pixel(x, y)[3];
+                    if alpha > 0 && alpha < 255 {
+                        found_partial = true;
+                        break;
+                    }
+                }
+                if found_partial {
+                    break;
+                }
+            }
+
+            assert!(
+                found_partial,
+                "should find at least one pixel with partial alpha in corner region"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_circle_coverage() {
+            // Pixel well inside the circle
+            let inside = circle_coverage(5.5, 5.5, 13.0, 13.0, 13.0);
+            assert!((inside - 1.0).abs() < 0.01, "inside should be ~1.0");
+
+            // Pixel well outside the circle
+            let outside = circle_coverage(0.5, 0.5, 13.0, 13.0, 13.0);
+            assert!(outside < 0.01, "outside should be ~0.0");
+
+            // Pixel on the edge should be ~0.5
+            let on_edge = circle_coverage(13.0, 0.0, 13.0, 13.0, 13.0);
+            assert!(
+                on_edge > 0.3 && on_edge < 0.7,
+                "edge should be ~0.5, got {}",
+                on_edge
+            );
+        }
+    }
+}
+
+/// ImageMagick implementation (original).
+mod imagemagick {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+        let e = Command::new("convert")
+            .arg(file.to_str().unwrap())
+            .arg("(")
+            .args(["+clone", "-alpha", "extract"])
+            .args([
+                "-draw",
+                &format!(
+                    "fill black polygon 0,0 0,{r} {r},0 fill white circle {r},{r} {r},0",
+                    r = RADIUS
+                ),
+            ])
+            .args(["(", "+clone", "-flip", ")"])
+            .args(["-compose", "Multiply", "-composite"])
+            .args(["(", "+clone", "-flop", ")"])
+            .args(["-compose", "Multiply", "-composite"])
+            .arg(")")
+            .args(["-alpha", "off", "-compose", "CopyOpacity", "-composite"])
+            .arg(file.to_str().unwrap())
+            .output()
+            .context("Cannot apply corner decor effect")?;
+
+        if !e.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/t-rec/src/core/decors/big_sur_corner.rs
+++ b/crates/t-rec/src/core/decors/big_sur_corner.rs
@@ -216,7 +216,6 @@ mod native {
                 half_out
             );
         }
-
     }
 }
 

--- a/crates/t-rec/src/core/decors/big_sur_corner.rs
+++ b/crates/t-rec/src/core/decors/big_sur_corner.rs
@@ -15,6 +15,16 @@ pub fn apply_corner_to_file(file: &Path) -> Result<()> {
     }
 }
 
+/// Native implementation (for benchmarking)
+pub fn apply_corner_to_file_native(file: &Path) -> Result<()> {
+    native::apply_corner_to_file(file)
+}
+
+/// ImageMagick implementation (for benchmarking)
+pub fn apply_corner_to_file_imagemagick(file: &Path) -> Result<()> {
+    imagemagick::apply_corner_to_file(file)
+}
+
 /// Native implementation using the image crate with anti-aliased corners.
 mod native {
     use super::*;
@@ -64,8 +74,8 @@ mod native {
     /// - 0.0 = fully outside (pixel transparent)
     /// - 0.0-1.0 = on the edge (smooth anti-aliased blend)
     fn corner_coverage(x: u32, y: u32, width: u32, height: u32, radius: f32) -> f32 {
-        let x = x as f32 + 0.5; // pixel center
-        let y = y as f32 + 0.5;
+        let x = x as f32; // use pixel coordinate (matches ImageMagick)
+        let y = y as f32;
         let w = width as f32;
         let h = height as f32;
 
@@ -102,7 +112,8 @@ mod native {
         let signed_distance = distance - radius;
 
         // Smooth falloff over ~1 pixel for anti-aliasing
-        (0.5 - signed_distance).clamp(0.0, 1.0)
+        // Bias inward so pixels on the edge stay opaque (matches ImageMagick rasterization)
+        (1.0 - signed_distance).clamp(0.0, 1.0)
     }
 
     #[cfg(test)]
@@ -189,14 +200,23 @@ mod native {
             let outside = circle_coverage(0.5, 0.5, 13.0, 13.0, 13.0);
             assert!(outside < 0.01, "outside should be ~0.0");
 
-            // Pixel on the edge should be ~0.5
+            // Pixel exactly on the edge should be ~1.0 (biased inward)
             let on_edge = circle_coverage(13.0, 0.0, 13.0, 13.0, 13.0);
             assert!(
-                on_edge > 0.3 && on_edge < 0.7,
-                "edge should be ~0.5, got {}",
+                (on_edge - 1.0).abs() < 0.01,
+                "edge should be ~1.0, got {}",
                 on_edge
             );
+
+            // Pixel 0.5 outside the edge should be ~0.5
+            let half_out = circle_coverage(13.0, -0.5, 13.0, 13.0, 13.0);
+            assert!(
+                half_out > 0.4 && half_out < 0.6,
+                "half pixel outside should be ~0.5, got {}",
+                half_out
+            );
         }
+
     }
 }
 

--- a/crates/t-rec/src/core/decors/big_sur_corner.rs
+++ b/crates/t-rec/src/core/decors/big_sur_corner.rs
@@ -1,51 +1,237 @@
 use std::path::Path;
-use std::process::Command;
-
-use anyhow::Context;
 
 use super::IMAGEMAGICK_CMD;
 use crate::core::Result;
 
-/// Apply corner radius effect to a single file.
-///
-/// Apply a corner radius decor effect via a chain of convert commands
-/// this makes sure big sur corner radius, that comes in with white color, does not mess up
-///
-/// ```sh
-/// convert t-rec-frame-000000251.bmp \
-///     \( +clone  -alpha extract \
-///         -draw 'fill black polygon 0,0 0,15 15,0 fill white circle 15,15 15,0' \
-///         \( +clone -flip \) -compose Multiply -composite \
-///         \( +clone -flop \) -compose Multiply -composite \
-///      \) -alpha off -compose CopyOpacity -composite \
-///    t-rec-frame-000000251.bmp
-/// ```
-pub fn apply_corner_to_file(file: &Path) -> Result<()> {
-    let radius = 13;
-    let e = Command::new(IMAGEMAGICK_CMD)
-        .arg(file.to_str().unwrap())
-        .arg("(")
-        .args(["+clone", "-alpha", "extract"])
-        .args([
-            "-draw",
-            &format!(
-                "fill black polygon 0,0 0,{r} {r},0 fill white circle {r},{r} {r},0",
-                r = radius
-            ),
-        ])
-        .args(["(", "+clone", "-flip", ")"])
-        .args(["-compose", "Multiply", "-composite"])
-        .args(["(", "+clone", "-flop", ")"])
-        .args(["-compose", "Multiply", "-composite"])
-        .arg(")")
-        .args(["-alpha", "off", "-compose", "CopyOpacity", "-composite"])
-        .arg(file.to_str().unwrap())
-        .output()
-        .context("Cannot apply corner decor effect")?;
+/// Corner radius in pixels (matches macOS Big Sur terminal style)
+const RADIUS: u32 = 13;
 
-    if !e.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+/// Apply corner radius effect to a single file.
+pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+    if cfg!(feature = "x-native-imgops") {
+        native::apply_corner_to_file(file)
     } else {
+        imagemagick::apply_corner_to_file(file)
+    }
+}
+
+/// Native implementation using the image crate with anti-aliased corners.
+mod native {
+    use super::*;
+    use anyhow::Context;
+    use image::{save_buffer, ColorType, Rgba};
+
+    /// Applies rounded corners with anti-aliasing by smoothly blending
+    /// the alpha channel for pixels near the corner radius edge.
+    pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+        let img = image::open(file).with_context(|| {
+            format!(
+                "Cannot open image file for corner effect: {}",
+                file.display()
+            )
+        })?;
+
+        let mut img = img.to_rgba8();
+        let (width, height) = img.dimensions();
+        let radius = RADIUS as f32;
+
+        // Apply rounded corners with anti-aliasing
+        for y in 0..height {
+            for x in 0..width {
+                let coverage = corner_coverage(x, y, width, height, radius);
+                if coverage < 1.0 {
+                    let pixel = img.get_pixel(x, y);
+                    let new_alpha = (pixel[3] as f32 * coverage) as u8;
+                    img.put_pixel(x, y, Rgba([pixel[0], pixel[1], pixel[2], new_alpha]));
+                }
+            }
+        }
+
+        save_buffer(file, img.as_raw(), width, height, ColorType::Rgba8).with_context(|| {
+            format!(
+                "Cannot save image file after corner effect: {}",
+                file.display()
+            )
+        })?;
+
         Ok(())
+    }
+
+    /// Calculate how much of a pixel is covered by the rounded corner area.
+    ///
+    /// Returns:
+    /// - 1.0 = fully inside (pixel unchanged)
+    /// - 0.0 = fully outside (pixel transparent)
+    /// - 0.0-1.0 = on the edge (smooth anti-aliased blend)
+    fn corner_coverage(x: u32, y: u32, width: u32, height: u32, radius: f32) -> f32 {
+        let x = x as f32 + 0.5; // pixel center
+        let y = y as f32 + 0.5;
+        let w = width as f32;
+        let h = height as f32;
+
+        // Top-left corner: circle center at (radius, radius)
+        if x < radius && y < radius {
+            return circle_coverage(x, y, radius, radius, radius);
+        }
+
+        // Top-right corner: circle center at (width - radius, radius)
+        if x > w - radius && y < radius {
+            return circle_coverage(x, y, w - radius, radius, radius);
+        }
+
+        // Bottom-left corner: circle center at (radius, height - radius)
+        if x < radius && y > h - radius {
+            return circle_coverage(x, y, radius, h - radius, radius);
+        }
+
+        // Bottom-right corner: circle center at (width - radius, height - radius)
+        if x > w - radius && y > h - radius {
+            return circle_coverage(x, y, w - radius, h - radius, radius);
+        }
+
+        1.0 // Not in a corner region
+    }
+
+    /// Calculate coverage for a pixel relative to a circle using signed distance.
+    fn circle_coverage(px: f32, py: f32, cx: f32, cy: f32, radius: f32) -> f32 {
+        let dx = px - cx;
+        let dy = py - cy;
+        let distance = (dx * dx + dy * dy).sqrt();
+
+        // Signed distance from circle edge (negative = inside, positive = outside)
+        let signed_distance = distance - radius;
+
+        // Smooth falloff over ~1 pixel for anti-aliasing
+        (0.5 - signed_distance).clamp(0.0, 1.0)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use image::{save_buffer, ColorType, Rgba, RgbaImage};
+        use tempfile::NamedTempFile;
+
+        #[test]
+        fn test_corners_are_transparent() -> Result<()> {
+            let mut img = RgbaImage::new(30, 30);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            let (w, h) = img.dimensions();
+            save_buffer(temp.path(), img.as_raw(), w, h, ColorType::Rgba8)?;
+
+            apply_corner_to_file(temp.path())?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Corners should be fully transparent
+            assert_eq!(result.get_pixel(0, 0)[3], 0, "top-left corner");
+            assert_eq!(result.get_pixel(29, 0)[3], 0, "top-right corner");
+            assert_eq!(result.get_pixel(0, 29)[3], 0, "bottom-left corner");
+            assert_eq!(result.get_pixel(29, 29)[3], 0, "bottom-right corner");
+
+            // Center should remain opaque
+            assert_eq!(result.get_pixel(15, 15)[3], 255, "center");
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_antialiasing_produces_partial_alpha() -> Result<()> {
+            let mut img = RgbaImage::new(50, 50);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            let (w, h) = img.dimensions();
+            save_buffer(temp.path(), img.as_raw(), w, h, ColorType::Rgba8)?;
+
+            apply_corner_to_file(temp.path())?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Find a pixel on the edge that should have partial alpha
+            // At radius=13, corner center is at (13, 13)
+            // For y=1 (center 1.5), distance to circle edge is at x ≈ 7
+            // Check multiple pixels along the edge to find one with partial alpha
+            let mut found_partial = false;
+            for x in 0..13u32 {
+                for y in 0..13u32 {
+                    let alpha = result.get_pixel(x, y)[3];
+                    if alpha > 0 && alpha < 255 {
+                        found_partial = true;
+                        break;
+                    }
+                }
+                if found_partial {
+                    break;
+                }
+            }
+
+            assert!(
+                found_partial,
+                "should find at least one pixel with partial alpha in corner region"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_circle_coverage() {
+            // Pixel well inside the circle
+            let inside = circle_coverage(5.5, 5.5, 13.0, 13.0, 13.0);
+            assert!((inside - 1.0).abs() < 0.01, "inside should be ~1.0");
+
+            // Pixel well outside the circle
+            let outside = circle_coverage(0.5, 0.5, 13.0, 13.0, 13.0);
+            assert!(outside < 0.01, "outside should be ~0.0");
+
+            // Pixel on the edge should be ~0.5
+            let on_edge = circle_coverage(13.0, 0.0, 13.0, 13.0, 13.0);
+            assert!(
+                on_edge > 0.3 && on_edge < 0.7,
+                "edge should be ~0.5, got {}",
+                on_edge
+            );
+        }
+    }
+}
+
+/// ImageMagick implementation (original).
+mod imagemagick {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn apply_corner_to_file(file: &Path) -> Result<()> {
+        let e = Command::new(IMAGEMAGICK_CMD)
+            .arg(file.to_str().unwrap())
+            .arg("(")
+            .args(["+clone", "-alpha", "extract"])
+            .args([
+                "-draw",
+                &format!(
+                    "fill black polygon 0,0 0,{r} {r},0 fill white circle {r},{r} {r},0",
+                    r = RADIUS
+                ),
+            ])
+            .args(["(", "+clone", "-flip", ")"])
+            .args(["-compose", "Multiply", "-composite"])
+            .args(["(", "+clone", "-flop", ")"])
+            .args(["-compose", "Multiply", "-composite"])
+            .arg(")")
+            .args(["-alpha", "off", "-compose", "CopyOpacity", "-composite"])
+            .arg(file.to_str().unwrap())
+            .output()
+            .context("Cannot apply corner decor effect")?;
+
+        if !e.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/t-rec/src/core/decors/mod.rs
+++ b/crates/t-rec/src/core/decors/mod.rs
@@ -3,3 +3,7 @@ mod shadow;
 
 pub use big_sur_corner::apply_corner_to_file;
 pub use shadow::apply_shadow_to_file;
+
+// Benchmark exports
+pub use big_sur_corner::{apply_corner_to_file_imagemagick, apply_corner_to_file_native};
+pub use shadow::{apply_shadow_to_file_imagemagick, apply_shadow_to_file_native};

--- a/crates/t-rec/src/core/decors/mod.rs
+++ b/crates/t-rec/src/core/decors/mod.rs
@@ -10,3 +10,7 @@ pub use shadow::apply_shadow_to_file;
 pub(crate) const IMAGEMAGICK_CMD: &str = "magick";
 #[cfg(not(target_os = "windows"))]
 pub(crate) const IMAGEMAGICK_CMD: &str = "convert";
+
+// Benchmark exports
+pub use big_sur_corner::{apply_corner_to_file_imagemagick, apply_corner_to_file_native};
+pub use shadow::{apply_shadow_to_file_imagemagick, apply_shadow_to_file_native};

--- a/crates/t-rec/src/core/decors/shadow.rs
+++ b/crates/t-rec/src/core/decors/shadow.rs
@@ -156,10 +156,10 @@ mod native {
         let mut kernel = vec![0.0; size];
         let mut sum = 0.0;
 
-        for i in 0..size {
+        for (i, item) in kernel.iter_mut().enumerate().take(size) {
             let x = (i as i32 - radius) as f32;
             let val = (-x * x / (2.0 * sigma * sigma)).exp();
-            kernel[i] = val;
+            *item = val;
             sum += val;
         }
 
@@ -204,13 +204,13 @@ mod native {
         // Horizontal pass - parallelize over rows
         let mut temp = vec![0.0; input.len()];
         temp.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
-            for x in 0..w {
+            for (x, px) in row.iter_mut().enumerate().take(w) {
                 let mut sum = 0.0;
                 for (i, &k) in kernel.iter().enumerate() {
                     let sx = (x as i32 + i as i32 - radius).clamp(0, wi - 1) as usize;
                     sum += input[y * w + sx] * k;
                 }
-                row[x] = sum;
+                *px = sum;
             }
         });
 

--- a/crates/t-rec/src/core/decors/shadow.rs
+++ b/crates/t-rec/src/core/decors/shadow.rs
@@ -1,34 +1,400 @@
 use std::path::Path;
-use std::process::Command;
-
-use anyhow::Context;
 
 use crate::core::Result;
 
-/// apply a border decor effect via a chain of convert commands
-///
-/// ```sh
-/// convert t-rec-frame-000000251.bmp \
-///     \( +clone -background black -shadow 140x10+0+0 \) \
-///     +swap -background white \
-///     -layers merge \
-///     t-rec-frame-000000251.bmp
-/// ```
-pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
-    let e = Command::new("convert")
-        .arg(file.to_str().unwrap())
-        .arg("(")
-        .args(["+clone", "-background", "black", "-shadow", "100x20+0+0"])
-        .arg(")")
-        .args(["+swap", "-background", bg_color])
-        .args(["-layers", "merge"])
-        .arg(file.to_str().unwrap())
-        .output()
-        .context("Cannot apply shadow decor effect")?;
+/// Shadow blur sigma (matches ImageMagick -shadow 100x20)
+const SHADOW_SIGMA: f32 = 20.0;
 
-    if !e.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+/// Padding around image for shadow spread (2 × sigma per ImageMagick docs)
+const SHADOW_PADDING: u32 = 40;
+
+/// Apply shadow effect to a single file.
+pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+    if cfg!(feature = "x-native-imgops") {
+        native::apply_shadow_to_file(file, bg_color)
     } else {
+        imagemagick::apply_shadow_to_file(file, bg_color)
+    }
+}
+
+/// Native implementation (for benchmarking)
+#[allow(dead_code)]
+pub fn apply_shadow_to_file_native(file: &Path, bg_color: &str) -> Result<()> {
+    native::apply_shadow_to_file(file, bg_color)
+}
+
+/// ImageMagick implementation (for benchmarking)
+#[allow(dead_code)]
+pub fn apply_shadow_to_file_imagemagick(file: &Path, bg_color: &str) -> Result<()> {
+    imagemagick::apply_shadow_to_file(file, bg_color)
+}
+
+/// Native implementation using the image crate.
+mod native {
+    use super::*;
+    use anyhow::Context;
+    use image::{save_buffer, ColorType, Rgba, RgbaImage};
+
+    pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+        let img = image::open(file).with_context(|| {
+            format!(
+                "Cannot open image file for shadow effect: {}",
+                file.display()
+            )
+        })?;
+
+        let img = img.to_rgba8();
+        let (width, height) = img.dimensions();
+
+        // Parse background color
+        let bg = parse_hex_color(bg_color).unwrap_or(Rgba([255, 255, 255, 255]));
+
+        // Create larger canvas with padding for shadow
+        let canvas_width = width + SHADOW_PADDING * 2;
+        let canvas_height = height + SHADOW_PADDING * 2;
+        let mut canvas = RgbaImage::from_pixel(canvas_width, canvas_height, bg);
+
+        // Create shadow layer (alpha from original, blurred)
+        let shadow = create_shadow(&img, canvas_width, canvas_height, SHADOW_PADDING);
+
+        // Composite shadow onto canvas
+        for y in 0..canvas_height {
+            for x in 0..canvas_width {
+                let shadow_pixel = shadow.get_pixel(x, y);
+                if shadow_pixel[3] > 0 {
+                    let canvas_pixel = canvas.get_pixel(x, y);
+                    let blended = alpha_blend(shadow_pixel, canvas_pixel);
+                    canvas.put_pixel(x, y, blended);
+                }
+            }
+        }
+
+        // Composite original image on top (centered)
+        for y in 0..height {
+            for x in 0..width {
+                let src = img.get_pixel(x, y);
+                let dst_x = x + SHADOW_PADDING;
+                let dst_y = y + SHADOW_PADDING;
+                let dst = canvas.get_pixel(dst_x, dst_y);
+                canvas.put_pixel(dst_x, dst_y, alpha_blend(src, dst));
+            }
+        }
+
+        save_buffer(
+            file,
+            canvas.as_raw(),
+            canvas_width,
+            canvas_height,
+            ColorType::Rgba8,
+        )
+        .with_context(|| {
+            format!(
+                "Cannot save image file after shadow effect: {}",
+                file.display()
+            )
+        })?;
+
         Ok(())
+    }
+
+    /// Creates a blurred shadow from the original image's alpha channel.
+    ///
+    /// The shadow effect works by:
+    /// 1. Extracting the alpha channel from the source image into a float buffer
+    /// 2. Centering it on a larger canvas (with padding for the blur spread)
+    /// 3. Applying a Gaussian blur to create the soft shadow falloff
+    /// 4. Converting the blurred alpha back to a black RGBA image
+    ///
+    /// The result is a semi-transparent black image where opacity decreases
+    /// smoothly from the original shape's edges outward.
+    fn create_shadow(img: &RgbaImage, canvas_w: u32, canvas_h: u32, padding: u32) -> RgbaImage {
+        let (w, h) = img.dimensions();
+
+        // Create alpha mask on canvas-sized buffer
+        let mut alpha_buffer: Vec<f32> = vec![0.0; (canvas_w * canvas_h) as usize];
+
+        // Copy alpha values to buffer (centered with padding)
+        for y in 0..h {
+            for x in 0..w {
+                let alpha = img.get_pixel(x, y)[3] as f32 / 255.0;
+                let idx = ((y + padding) * canvas_w + (x + padding)) as usize;
+                alpha_buffer[idx] = alpha;
+            }
+        }
+
+        // Apply Gaussian blur (separable: horizontal then vertical)
+        let kernel = gaussian_kernel(SHADOW_SIGMA);
+        let blurred = blur_separable(&alpha_buffer, canvas_w, canvas_h, &kernel);
+
+        // Convert to shadow image (black with blurred alpha)
+        let mut shadow = RgbaImage::new(canvas_w, canvas_h);
+        for y in 0..canvas_h {
+            for x in 0..canvas_w {
+                let idx = (y * canvas_w + x) as usize;
+                let alpha = (blurred[idx] * 255.0).min(255.0) as u8;
+                shadow.put_pixel(x, y, Rgba([0, 0, 0, alpha]));
+            }
+        }
+
+        shadow
+    }
+
+    /// Generates a 1D Gaussian kernel for convolution.
+    ///
+    /// The Gaussian function G(x) = e^(-x²/2σ²) creates a bell curve where:
+    /// - σ (sigma) controls the spread/width of the blur
+    /// - Higher σ = wider blur, softer shadow edges
+    /// - Lower σ = tighter blur, sharper shadow edges
+    ///
+    /// The kernel radius is set to 3σ because the Gaussian function drops to
+    /// ~0.01% of its peak at 3σ, making values beyond negligible (99.7% rule).
+    ///
+    /// The kernel is normalized (sums to 1.0) to preserve overall brightness.
+    fn gaussian_kernel(sigma: f32) -> Vec<f32> {
+        let radius = (sigma * 3.0).ceil() as i32;
+        let size = (radius * 2 + 1) as usize;
+        let mut kernel = vec![0.0; size];
+        let mut sum = 0.0;
+
+        for i in 0..size {
+            let x = (i as i32 - radius) as f32;
+            let val = (-x * x / (2.0 * sigma * sigma)).exp();
+            kernel[i] = val;
+            sum += val;
+        }
+
+        // Normalize
+        for v in &mut kernel {
+            *v /= sum;
+        }
+
+        kernel
+    }
+
+    /// Applies Gaussian blur using the separable filter optimization.
+    ///
+    /// # Why Separable?
+    /// A 2D Gaussian blur is "separable", meaning it can be decomposed into
+    /// two 1D passes (horizontal then vertical). This reduces complexity from
+    /// O(width × height × kernel_size²) to O(width × height × kernel_size × 2).
+    ///
+    /// For a kernel size of 121 (σ=20), this is ~60x faster than naive 2D convolution.
+    ///
+    /// # How It Works
+    /// ```text
+    /// Original → [Horizontal 1D blur] → Intermediate → [Vertical 1D blur] → Result
+    /// ```
+    ///
+    /// Each pass slides the 1D kernel across the image:
+    /// - Horizontal: for each pixel, sum weighted neighbors along the row
+    /// - Vertical: for each pixel, sum weighted neighbors along the column
+    ///
+    /// # Parallelization
+    /// Both passes are parallelized over rows using rayon's `par_chunks_mut`.
+    /// Each row's computation is independent, making this embarrassingly parallel.
+    /// Edge pixels use clamped sampling (repeat edge values) to avoid artifacts.
+    fn blur_separable(input: &[f32], width: u32, height: u32, kernel: &[f32]) -> Vec<f32> {
+        use rayon::prelude::*;
+
+        let radius = (kernel.len() / 2) as i32;
+        let w = width as usize;
+        let wi = width as i32;
+        let hi = height as i32;
+
+        // Horizontal pass - parallelize over rows
+        let mut temp = vec![0.0; input.len()];
+        temp.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
+            for x in 0..w {
+                let mut sum = 0.0;
+                for (i, &k) in kernel.iter().enumerate() {
+                    let sx = (x as i32 + i as i32 - radius).clamp(0, wi - 1) as usize;
+                    sum += input[y * w + sx] * k;
+                }
+                row[x] = sum;
+            }
+        });
+
+        // Vertical pass - parallelize over rows
+        let mut output = vec![0.0; input.len()];
+        output.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
+            for x in 0..w {
+                let mut sum = 0.0;
+                for (i, &k) in kernel.iter().enumerate() {
+                    let sy = (y as i32 + i as i32 - radius).clamp(0, hi - 1) as usize;
+                    sum += temp[sy * w + x] * k;
+                }
+                row[x] = sum;
+            }
+        });
+
+        output
+    }
+
+    /// Composites source over destination using Porter-Duff "over" operator.
+    ///
+    /// This is the standard alpha compositing formula used in image editing:
+    /// ```text
+    /// out_alpha = src_alpha + dst_alpha × (1 - src_alpha)
+    /// out_color = (src_color × src_alpha + dst_color × dst_alpha × (1 - src_alpha)) / out_alpha
+    /// ```
+    ///
+    /// The formula handles:
+    /// - Fully opaque src (α=1): completely replaces dst
+    /// - Fully transparent src (α=0): dst shows through unchanged
+    /// - Semi-transparent src: blends proportionally with dst
+    fn alpha_blend(src: &Rgba<u8>, dst: &Rgba<u8>) -> Rgba<u8> {
+        let sa = src[3] as f32 / 255.0;
+        let da = dst[3] as f32 / 255.0;
+
+        let out_a = sa + da * (1.0 - sa);
+        if out_a == 0.0 {
+            return Rgba([0, 0, 0, 0]);
+        }
+
+        let blend = |s: u8, d: u8| -> u8 {
+            let s = s as f32 / 255.0;
+            let d = d as f32 / 255.0;
+            let out = (s * sa + d * da * (1.0 - sa)) / out_a;
+            (out * 255.0) as u8
+        };
+
+        Rgba([
+            blend(src[0], dst[0]),
+            blend(src[1], dst[1]),
+            blend(src[2], dst[2]),
+            (out_a * 255.0) as u8,
+        ])
+    }
+
+    /// Parse hex color string (e.g., "#ffffff" or "white").
+    fn parse_hex_color(color: &str) -> Option<Rgba<u8>> {
+        let color = color.trim().to_lowercase();
+
+        // Named colors
+        match color.as_str() {
+            "white" => return Some(Rgba([255, 255, 255, 255])),
+            "black" => return Some(Rgba([0, 0, 0, 255])),
+            "transparent" => return Some(Rgba([0, 0, 0, 0])),
+            _ => {}
+        }
+
+        // Hex format
+        let hex = color.strip_prefix('#').unwrap_or(&color);
+        if hex.len() == 6 {
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            return Some(Rgba([r, g, b, 255]));
+        }
+
+        None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use tempfile::NamedTempFile;
+
+        #[test]
+        fn test_shadow_increases_image_size() -> Result<()> {
+            // Create small test image
+            let mut img = RgbaImage::new(100, 100);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            save_buffer(temp.path(), img.as_raw(), 100, 100, ColorType::Rgba8)?;
+
+            apply_shadow_to_file(temp.path(), "white")?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+            let (w, h) = result.dimensions();
+
+            // Should be larger due to shadow padding
+            assert_eq!(w, 100 + SHADOW_PADDING * 2);
+            assert_eq!(h, 100 + SHADOW_PADDING * 2);
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_shadow_has_gradient_alpha() -> Result<()> {
+            let mut img = RgbaImage::new(50, 50);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            save_buffer(temp.path(), img.as_raw(), 50, 50, ColorType::Rgba8)?;
+
+            apply_shadow_to_file(temp.path(), "#ffffff")?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Check that shadow region has varying alpha (gradient from blur)
+            // Sample pixels in the padding area
+            let mut found_partial = false;
+            for x in 0..SHADOW_PADDING {
+                let pixel = result.get_pixel(x, SHADOW_PADDING + 25);
+                // Shadow should blend with white background, creating gray tones
+                if pixel[0] < 255 && pixel[0] > 0 {
+                    found_partial = true;
+                    break;
+                }
+            }
+
+            assert!(
+                found_partial,
+                "shadow should create gradient in padding area"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_parse_hex_color() {
+            assert_eq!(parse_hex_color("white"), Some(Rgba([255, 255, 255, 255])));
+            assert_eq!(parse_hex_color("#ff0000"), Some(Rgba([255, 0, 0, 255])));
+            assert_eq!(parse_hex_color("000000"), Some(Rgba([0, 0, 0, 255])));
+            assert_eq!(parse_hex_color("#ABC123"), Some(Rgba([171, 193, 35, 255])));
+        }
+
+        #[test]
+        fn test_gaussian_kernel_sums_to_one() {
+            let kernel = gaussian_kernel(10.0);
+            let sum: f32 = kernel.iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 0.001,
+                "kernel should sum to 1.0, got {}",
+                sum
+            );
+        }
+    }
+}
+
+/// ImageMagick implementation (original).
+mod imagemagick {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+        let e = Command::new("convert")
+            .arg(file.to_str().unwrap())
+            .arg("(")
+            .args(["+clone", "-background", "black", "-shadow", "100x20+0+0"])
+            .arg(")")
+            .args(["+swap", "-background", bg_color])
+            .args(["-layers", "merge"])
+            .arg(file.to_str().unwrap())
+            .output()
+            .context("Cannot apply shadow decor effect")?;
+
+        if !e.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/t-rec/src/core/decors/shadow.rs
+++ b/crates/t-rec/src/core/decors/shadow.rs
@@ -1,35 +1,401 @@
 use std::path::Path;
-use std::process::Command;
-
-use anyhow::Context;
 
 use super::IMAGEMAGICK_CMD;
 use crate::core::Result;
 
-/// apply a border decor effect via a chain of convert commands
-///
-/// ```sh
-/// convert t-rec-frame-000000251.bmp \
-///     \( +clone -background black -shadow 140x10+0+0 \) \
-///     +swap -background white \
-///     -layers merge \
-///     t-rec-frame-000000251.bmp
-/// ```
-pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
-    let e = Command::new(IMAGEMAGICK_CMD)
-        .arg(file.to_str().unwrap())
-        .arg("(")
-        .args(["+clone", "-background", "black", "-shadow", "100x20+0+0"])
-        .arg(")")
-        .args(["+swap", "-background", bg_color])
-        .args(["-layers", "merge"])
-        .arg(file.to_str().unwrap())
-        .output()
-        .context("Cannot apply shadow decor effect")?;
+/// Shadow blur sigma (matches ImageMagick -shadow 100x20)
+const SHADOW_SIGMA: f32 = 20.0;
 
-    if !e.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+/// Padding around image for shadow spread (2 × sigma per ImageMagick docs)
+const SHADOW_PADDING: u32 = 40;
+
+/// Apply shadow effect to a single file.
+pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+    if cfg!(feature = "x-native-imgops") {
+        native::apply_shadow_to_file(file, bg_color)
     } else {
+        imagemagick::apply_shadow_to_file(file, bg_color)
+    }
+}
+
+/// Native implementation (for benchmarking)
+#[allow(dead_code)]
+pub fn apply_shadow_to_file_native(file: &Path, bg_color: &str) -> Result<()> {
+    native::apply_shadow_to_file(file, bg_color)
+}
+
+/// ImageMagick implementation (for benchmarking)
+#[allow(dead_code)]
+pub fn apply_shadow_to_file_imagemagick(file: &Path, bg_color: &str) -> Result<()> {
+    imagemagick::apply_shadow_to_file(file, bg_color)
+}
+
+/// Native implementation using the image crate.
+mod native {
+    use super::*;
+    use anyhow::Context;
+    use image::{save_buffer, ColorType, Rgba, RgbaImage};
+
+    pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+        let img = image::open(file).with_context(|| {
+            format!(
+                "Cannot open image file for shadow effect: {}",
+                file.display()
+            )
+        })?;
+
+        let img = img.to_rgba8();
+        let (width, height) = img.dimensions();
+
+        // Parse background color
+        let bg = parse_hex_color(bg_color).unwrap_or(Rgba([255, 255, 255, 255]));
+
+        // Create larger canvas with padding for shadow
+        let canvas_width = width + SHADOW_PADDING * 2;
+        let canvas_height = height + SHADOW_PADDING * 2;
+        let mut canvas = RgbaImage::from_pixel(canvas_width, canvas_height, bg);
+
+        // Create shadow layer (alpha from original, blurred)
+        let shadow = create_shadow(&img, canvas_width, canvas_height, SHADOW_PADDING);
+
+        // Composite shadow onto canvas
+        for y in 0..canvas_height {
+            for x in 0..canvas_width {
+                let shadow_pixel = shadow.get_pixel(x, y);
+                if shadow_pixel[3] > 0 {
+                    let canvas_pixel = canvas.get_pixel(x, y);
+                    let blended = alpha_blend(shadow_pixel, canvas_pixel);
+                    canvas.put_pixel(x, y, blended);
+                }
+            }
+        }
+
+        // Composite original image on top (centered)
+        for y in 0..height {
+            for x in 0..width {
+                let src = img.get_pixel(x, y);
+                let dst_x = x + SHADOW_PADDING;
+                let dst_y = y + SHADOW_PADDING;
+                let dst = canvas.get_pixel(dst_x, dst_y);
+                canvas.put_pixel(dst_x, dst_y, alpha_blend(src, dst));
+            }
+        }
+
+        save_buffer(
+            file,
+            canvas.as_raw(),
+            canvas_width,
+            canvas_height,
+            ColorType::Rgba8,
+        )
+        .with_context(|| {
+            format!(
+                "Cannot save image file after shadow effect: {}",
+                file.display()
+            )
+        })?;
+
         Ok(())
+    }
+
+    /// Creates a blurred shadow from the original image's alpha channel.
+    ///
+    /// The shadow effect works by:
+    /// 1. Extracting the alpha channel from the source image into a float buffer
+    /// 2. Centering it on a larger canvas (with padding for the blur spread)
+    /// 3. Applying a Gaussian blur to create the soft shadow falloff
+    /// 4. Converting the blurred alpha back to a black RGBA image
+    ///
+    /// The result is a semi-transparent black image where opacity decreases
+    /// smoothly from the original shape's edges outward.
+    fn create_shadow(img: &RgbaImage, canvas_w: u32, canvas_h: u32, padding: u32) -> RgbaImage {
+        let (w, h) = img.dimensions();
+
+        // Create alpha mask on canvas-sized buffer
+        let mut alpha_buffer: Vec<f32> = vec![0.0; (canvas_w * canvas_h) as usize];
+
+        // Copy alpha values to buffer (centered with padding)
+        for y in 0..h {
+            for x in 0..w {
+                let alpha = img.get_pixel(x, y)[3] as f32 / 255.0;
+                let idx = ((y + padding) * canvas_w + (x + padding)) as usize;
+                alpha_buffer[idx] = alpha;
+            }
+        }
+
+        // Apply Gaussian blur (separable: horizontal then vertical)
+        let kernel = gaussian_kernel(SHADOW_SIGMA);
+        let blurred = blur_separable(&alpha_buffer, canvas_w, canvas_h, &kernel);
+
+        // Convert to shadow image (black with blurred alpha)
+        let mut shadow = RgbaImage::new(canvas_w, canvas_h);
+        for y in 0..canvas_h {
+            for x in 0..canvas_w {
+                let idx = (y * canvas_w + x) as usize;
+                let alpha = (blurred[idx] * 255.0).min(255.0) as u8;
+                shadow.put_pixel(x, y, Rgba([0, 0, 0, alpha]));
+            }
+        }
+
+        shadow
+    }
+
+    /// Generates a 1D Gaussian kernel for convolution.
+    ///
+    /// The Gaussian function G(x) = e^(-x²/2σ²) creates a bell curve where:
+    /// - σ (sigma) controls the spread/width of the blur
+    /// - Higher σ = wider blur, softer shadow edges
+    /// - Lower σ = tighter blur, sharper shadow edges
+    ///
+    /// The kernel radius is set to 3σ because the Gaussian function drops to
+    /// ~0.01% of its peak at 3σ, making values beyond negligible (99.7% rule).
+    ///
+    /// The kernel is normalized (sums to 1.0) to preserve overall brightness.
+    fn gaussian_kernel(sigma: f32) -> Vec<f32> {
+        let radius = (sigma * 3.0).ceil() as i32;
+        let size = (radius * 2 + 1) as usize;
+        let mut kernel = vec![0.0; size];
+        let mut sum = 0.0;
+
+        for i in 0..size {
+            let x = (i as i32 - radius) as f32;
+            let val = (-x * x / (2.0 * sigma * sigma)).exp();
+            kernel[i] = val;
+            sum += val;
+        }
+
+        // Normalize
+        for v in &mut kernel {
+            *v /= sum;
+        }
+
+        kernel
+    }
+
+    /// Applies Gaussian blur using the separable filter optimization.
+    ///
+    /// # Why Separable?
+    /// A 2D Gaussian blur is "separable", meaning it can be decomposed into
+    /// two 1D passes (horizontal then vertical). This reduces complexity from
+    /// O(width × height × kernel_size²) to O(width × height × kernel_size × 2).
+    ///
+    /// For a kernel size of 121 (σ=20), this is ~60x faster than naive 2D convolution.
+    ///
+    /// # How It Works
+    /// ```text
+    /// Original → [Horizontal 1D blur] → Intermediate → [Vertical 1D blur] → Result
+    /// ```
+    ///
+    /// Each pass slides the 1D kernel across the image:
+    /// - Horizontal: for each pixel, sum weighted neighbors along the row
+    /// - Vertical: for each pixel, sum weighted neighbors along the column
+    ///
+    /// # Parallelization
+    /// Both passes are parallelized over rows using rayon's `par_chunks_mut`.
+    /// Each row's computation is independent, making this embarrassingly parallel.
+    /// Edge pixels use clamped sampling (repeat edge values) to avoid artifacts.
+    fn blur_separable(input: &[f32], width: u32, height: u32, kernel: &[f32]) -> Vec<f32> {
+        use rayon::prelude::*;
+
+        let radius = (kernel.len() / 2) as i32;
+        let w = width as usize;
+        let wi = width as i32;
+        let hi = height as i32;
+
+        // Horizontal pass - parallelize over rows
+        let mut temp = vec![0.0; input.len()];
+        temp.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
+            for x in 0..w {
+                let mut sum = 0.0;
+                for (i, &k) in kernel.iter().enumerate() {
+                    let sx = (x as i32 + i as i32 - radius).clamp(0, wi - 1) as usize;
+                    sum += input[y * w + sx] * k;
+                }
+                row[x] = sum;
+            }
+        });
+
+        // Vertical pass - parallelize over rows
+        let mut output = vec![0.0; input.len()];
+        output.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
+            for x in 0..w {
+                let mut sum = 0.0;
+                for (i, &k) in kernel.iter().enumerate() {
+                    let sy = (y as i32 + i as i32 - radius).clamp(0, hi - 1) as usize;
+                    sum += temp[sy * w + x] * k;
+                }
+                row[x] = sum;
+            }
+        });
+
+        output
+    }
+
+    /// Composites source over destination using Porter-Duff "over" operator.
+    ///
+    /// This is the standard alpha compositing formula used in image editing:
+    /// ```text
+    /// out_alpha = src_alpha + dst_alpha × (1 - src_alpha)
+    /// out_color = (src_color × src_alpha + dst_color × dst_alpha × (1 - src_alpha)) / out_alpha
+    /// ```
+    ///
+    /// The formula handles:
+    /// - Fully opaque src (α=1): completely replaces dst
+    /// - Fully transparent src (α=0): dst shows through unchanged
+    /// - Semi-transparent src: blends proportionally with dst
+    fn alpha_blend(src: &Rgba<u8>, dst: &Rgba<u8>) -> Rgba<u8> {
+        let sa = src[3] as f32 / 255.0;
+        let da = dst[3] as f32 / 255.0;
+
+        let out_a = sa + da * (1.0 - sa);
+        if out_a == 0.0 {
+            return Rgba([0, 0, 0, 0]);
+        }
+
+        let blend = |s: u8, d: u8| -> u8 {
+            let s = s as f32 / 255.0;
+            let d = d as f32 / 255.0;
+            let out = (s * sa + d * da * (1.0 - sa)) / out_a;
+            (out * 255.0) as u8
+        };
+
+        Rgba([
+            blend(src[0], dst[0]),
+            blend(src[1], dst[1]),
+            blend(src[2], dst[2]),
+            (out_a * 255.0) as u8,
+        ])
+    }
+
+    /// Parse hex color string (e.g., "#ffffff" or "white").
+    fn parse_hex_color(color: &str) -> Option<Rgba<u8>> {
+        let color = color.trim().to_lowercase();
+
+        // Named colors
+        match color.as_str() {
+            "white" => return Some(Rgba([255, 255, 255, 255])),
+            "black" => return Some(Rgba([0, 0, 0, 255])),
+            "transparent" => return Some(Rgba([0, 0, 0, 0])),
+            _ => {}
+        }
+
+        // Hex format
+        let hex = color.strip_prefix('#').unwrap_or(&color);
+        if hex.len() == 6 {
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            return Some(Rgba([r, g, b, 255]));
+        }
+
+        None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use tempfile::NamedTempFile;
+
+        #[test]
+        fn test_shadow_increases_image_size() -> Result<()> {
+            // Create small test image
+            let mut img = RgbaImage::new(100, 100);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            save_buffer(temp.path(), img.as_raw(), 100, 100, ColorType::Rgba8)?;
+
+            apply_shadow_to_file(temp.path(), "white")?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+            let (w, h) = result.dimensions();
+
+            // Should be larger due to shadow padding
+            assert_eq!(w, 100 + SHADOW_PADDING * 2);
+            assert_eq!(h, 100 + SHADOW_PADDING * 2);
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_shadow_has_gradient_alpha() -> Result<()> {
+            let mut img = RgbaImage::new(50, 50);
+            for pixel in img.pixels_mut() {
+                *pixel = Rgba([255, 0, 0, 255]);
+            }
+
+            let temp = NamedTempFile::with_suffix(".bmp")?;
+            save_buffer(temp.path(), img.as_raw(), 50, 50, ColorType::Rgba8)?;
+
+            apply_shadow_to_file(temp.path(), "#ffffff")?;
+
+            let result = image::open(temp.path())?.to_rgba8();
+
+            // Check that shadow region has varying alpha (gradient from blur)
+            // Sample pixels in the padding area
+            let mut found_partial = false;
+            for x in 0..SHADOW_PADDING {
+                let pixel = result.get_pixel(x, SHADOW_PADDING + 25);
+                // Shadow should blend with white background, creating gray tones
+                if pixel[0] < 255 && pixel[0] > 0 {
+                    found_partial = true;
+                    break;
+                }
+            }
+
+            assert!(
+                found_partial,
+                "shadow should create gradient in padding area"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_parse_hex_color() {
+            assert_eq!(parse_hex_color("white"), Some(Rgba([255, 255, 255, 255])));
+            assert_eq!(parse_hex_color("#ff0000"), Some(Rgba([255, 0, 0, 255])));
+            assert_eq!(parse_hex_color("000000"), Some(Rgba([0, 0, 0, 255])));
+            assert_eq!(parse_hex_color("#ABC123"), Some(Rgba([171, 193, 35, 255])));
+        }
+
+        #[test]
+        fn test_gaussian_kernel_sums_to_one() {
+            let kernel = gaussian_kernel(10.0);
+            let sum: f32 = kernel.iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 0.001,
+                "kernel should sum to 1.0, got {}",
+                sum
+            );
+        }
+    }
+}
+
+/// ImageMagick implementation (original).
+mod imagemagick {
+    use super::*;
+    use anyhow::Context;
+    use std::process::Command;
+
+    pub fn apply_shadow_to_file(file: &Path, bg_color: &str) -> Result<()> {
+        let e = Command::new(IMAGEMAGICK_CMD)
+            .arg(file.to_str().unwrap())
+            .arg("(")
+            .args(["+clone", "-background", "black", "-shadow", "100x20+0+0"])
+            .arg(")")
+            .args(["+swap", "-background", bg_color])
+            .args(["-layers", "merge"])
+            .arg(file.to_str().unwrap())
+            .output()
+            .context("Cannot apply shadow decor effect")?;
+
+        if !e.status.success() {
+            anyhow::bail!("{}", String::from_utf8_lossy(&e.stderr))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/crates/t-rec/src/core/decors/shadow.rs
+++ b/crates/t-rec/src/core/decors/shadow.rs
@@ -157,10 +157,10 @@ mod native {
         let mut kernel = vec![0.0; size];
         let mut sum = 0.0;
 
-        for i in 0..size {
+        for (i, item) in kernel.iter_mut().enumerate().take(size) {
             let x = (i as i32 - radius) as f32;
             let val = (-x * x / (2.0 * sigma * sigma)).exp();
-            kernel[i] = val;
+            *item = val;
             sum += val;
         }
 
@@ -205,13 +205,13 @@ mod native {
         // Horizontal pass - parallelize over rows
         let mut temp = vec![0.0; input.len()];
         temp.par_chunks_mut(w).enumerate().for_each(|(y, row)| {
-            for x in 0..w {
+            for (x, px) in row.iter_mut().enumerate().take(w) {
                 let mut sum = 0.0;
                 for (i, &k) in kernel.iter().enumerate() {
                     let sx = (x as i32 + i as i32 - radius).clamp(0, wi - 1) as usize;
                     sum += input[y * w + sx] * k;
                 }
-                row[x] = sum;
+                *px = sum;
             }
         });
 


### PR DESCRIPTION
## Summary

- Addresses partially #5 
  - [x] got rid of imagemagick on the post processing of frames
  - follow-up: the final gif composition still depends on imagemagick 
- Native rounded corners and shadow effects via `x-native-imgops` feature flag
- Gaussian blur uses separable convolution: O(w×h×k²) → O(w×h×k×2), ~60x algorithmic speedup
- Row-parallel processing with rayon's `par_chunks_mut`
- 800×800 shadow: ~140ms → ~23ms (83% faster), 3x faster than ImageMagick

## Benchmarks

```sh
cargo bench -p t-rec --features x-native-imgops --bench decors_benchmark -- --sample-size 10 --warm-up-time 1
# or: cargo b:run --features x-native-imgops
```

## Test plan

- [x] `cargo test --features x-native-imgops -p t-rec`
- [x] Benchmark comparisons against ImageMagick baseline

## Shadow difference

<img width="960" height="540" style="background-color: white!" alt="image" src="https://github.com/user-attachments/assets/30bbc319-75d5-446c-a522-53f63d2a0606" />

## Corner difference
<img width="960" height="540" style="background-color: white!" alt="image" src="https://github.com/user-attachments/assets/11e36151-6f56-44eb-9ebe-40ae0ff64e30" />

