### PR TITLE
ci: add typos spell check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,18 @@ name: Build
 on:
   push:
     branches: ["*"]
-    paths-ignore:
-      - "**/docs/**"
-      - "**.md"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/docs/**"
-      - "**.md"
   workflow_call:
 
 jobs:
+  spellcheck:
+    name: spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
+
   check:
     name: check
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-    paths-ignore:
-      - "**/docs/**"
-      - "**.md"
   workflow_dispatch:
     inputs:
       version:

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# macOS Big Sur
+sur = "sur"

--- a/crates/t-rec/src/cli/input/mod.rs
+++ b/crates/t-rec/src/cli/input/mod.rs
@@ -254,7 +254,7 @@ impl KeyboardMonitor {
             }
 
             // Toggle keystroke capture hotkey
-            // todo: this is currenlty not enabled
+            // todo: this is currently not enabled
             if self.hotkey_config.toggle_keystroke_capturing.as_ref() == Some(&hot_key) {
                 let enabled = self.input_state.toggle_capture();
                 log::debug!("Keystroke capture: {}", if enabled { "ON" } else { "OFF" });

--- a/crates/t-rec/src/cli/recorder/session.rs
+++ b/crates/t-rec/src/cli/recorder/session.rs
@@ -214,7 +214,7 @@ pub struct RecordingSession {
     config: SessionConfig,
     api: Box<dyn PlatformApi>,
     runtime: Runtime,
-    // todo: introdcue the `CatpureContext` on this level
+    // todo: introduce the `CaptureContext` on this level
 }
 
 impl RecordingSession {


### PR DESCRIPTION
## Summary
- Adds `crate-ci/typos` CI step to catch spelling errors in code, comments, and markdown
- Removes `paths-ignore` for docs/markdown so the full CI runs on all changes
- Fixes existing typos found by the tool
- Adds `_typos.toml` config to allow "sur" (macOS Big Sur references)

## Test plan
- [x] `typos` passes locally with zero findings
- [x] CI spellcheck job runs green on this PR