### PR TITLE
ci: auto-submit a winget manifest on stable releases

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Publish via Komac
         uses: vedantmgoyal9/winget-releaser@main
         with:
-          # Sticking with PascalCase as the winget convention.
-          identifier: Sassman.TRec
+          # winget identifiers allow ASCII letters, digits, hyphens, dots, and
+          # underscores. Hyphenated form keeps the package name recognisable.
+          identifier: Sassman.T-Rec
           # Matches `t-rec.exe-vX.Y.Z-x86_64-pc-windows-msvc.zip` produced by
           # release-binary-assets.yml.
           installers-regex: 'x86_64-pc-windows-msvc\.zip$'

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,46 @@
+name: Publish to winget
+
+# Submits a manifest update to microsoft/winget-pkgs whenever a non-prerelease
+# GitHub Release is published. The `released` event type fires only for
+# stable releases, so pre-releases such as `v0.9.0-preview1` are skipped
+# automatically — winget-pkgs does not accept pre-releases.
+#
+# One-off setup required for this to work:
+#   1. Fork https://github.com/microsoft/winget-pkgs to the account behind
+#      WINGET_TOKEN (otherwise Komac has nowhere to push a PR branch).
+#   2. Create a Classic Personal Access Token with `public_repo` scope (the
+#      action uses it to fork-and-PR against winget-pkgs).
+#   3. Store the token as the repository secret `WINGET_TOKEN`.
+#
+# After v0.9.0 ships, the first PR that lands the manifest in winget-pkgs
+# needs a manual review by a Microsoft maintainer; subsequent version bumps
+# are auto-approved by their bot.
+
+on:
+  release:
+    types: [released]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.9.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Submit manifest to winget-pkgs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish via Komac
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          # Sticking with PascalCase as the winget convention.
+          identifier: Sassman.TRec
+          # Matches `t-rec.exe-vX.Y.Z-x86_64-pc-windows-msvc.zip` produced by
+          # release-binary-assets.yml.
+          installers-regex: 'x86_64-pc-windows-msvc\.zip$'
+          release-tag: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a `winget-publish.yml` workflow that opens a manifest PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) whenever a non-prerelease GitHub Release is published. Wraps Komac via `vedantmgoyal9/winget-releaser`.

Intended for the **v0.9.0 stable** release — not active for the upcoming `v0.9.0-preview1`, because winget-pkgs only accepts stable versions and the `release: released` event we trigger on filters pre-releases out automatically.

## What this gives users

After this lands and a stable release ships, Windows users can install via:

```powershell
winget install Sassman.T-Rec
```

instead of the current `cargo install --version` route.

## One-off setup before the first stable tag

1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) to the account behind `WINGET_TOKEN` — Komac needs somewhere to push the manifest branch.
2. Generate a **Classic** Personal Access Token with the `public_repo` scope (fine-grained tokens don't work well for cross-repo PR flows).
3. Store the token in repo settings as the secret `WINGET_TOKEN`.

The first PR against winget-pkgs requires a manual review by a Microsoft maintainer; subsequent version bumps go through their auto-approval bot.

## Decisions worth flagging

- **Identifier `Sassman.T-Rec`** — hyphenated to match the binary and repo names. Adjust if you want a different shape; it just needs to match what's registered on the first submission.
- **Action choice** — went with `vedantmgoyal9/winget-releaser` since it's the most widely-used wrapper. An alternative is invoking Komac directly via `cargo install komac` in a step; happy to switch if you'd rather not depend on the third-party action.

## Test plan

- [x] Add `WINGET_TOKEN` secret and fork winget-pkgs.
- [ ] After v0.9.0 stable is tagged, confirm the workflow runs and an outbound PR appears under your fork → microsoft/winget-pkgs.
- [ ] Verify the published manifest installs cleanly with `winget install Sassman.T-Rec` on a fresh Windows 10/11 VM.