### PR TITLE
fix: unblock v0.9.0-preview1 publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: stable
           default: true
           profile: minimal
-      - uses: katyo/publish-crates@v1
+      - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/crates/t-rec/Cargo.toml
+++ b/crates/t-rec/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "t-rec"
-version = "0.8.1"
-authors = ["Sven Kanoldt <sven@d34dl0ck.me>"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 edition = "2018"
-license = "GPL-3.0-only"
 description = "Blazingly fast terminal recorder that generates animated gif images for the web written in rust."
 homepage = "https://github.com/sassman/t-rec-rs"
 readme = "../../README.md"
 keywords = ["recorder", "image", "terminal", "gif", "commandline"]
 categories = ["multimedia::images", "command-line-utilities"]
-repository = "https://github.com/sassman/t-rec-rs"
 links = "X11"
 build = "build.rs"
 include = ["src/**/*", "resources/**/*", "../../LICENSE", "../../*.md", "build.rs"]


### PR DESCRIPTION
## Summary

Two distinct issues surfaced when the v0.9.0-preview1 publish failed. Local `cargo publish --dry-run` confirms both fixes are needed.

### 1. `katyo/publish-crates@v1` doesn't resolve workspace deps

The action errored with:

> Error: Missing dependency 'anyhow' version field

…because v1 inspects the raw manifest without expanding `dependency.workspace = true`. Cargo itself handles this fine (verified locally) — v1 is the only thing that needs convincing. Bumping to v2.

### 2. The t-rec package was still pinned at 0.8.1

`crates/t-rec/Cargo.toml` hardcoded `version = "0.8.1"`. The root `Cargo.toml` had moved to `0.9.0-preview1`, but t-rec didn't inherit from `[workspace.package]`. Result: even if the publish action had worked, `cargo publish` would have tried to upload `0.8.1`, which already exists on crates.io.

Wired `version`, `authors`, `license`, and `repository` to inherit via `*.workspace = true`. Future releases only need a single bump in the root manifest. Left `edition` hardcoded at `2018` — bumping to the workspace value `2021` is a code-affecting change for its own commit.

## Verification

```
$ cargo publish -p t-rec --dry-run --allow-dirty
   Packaging t-rec v0.9.0-preview1 (...)
   ...
warning: aborting upload due to dry run
```

(Before: `warning: crate t-rec@0.8.1 already exists on crates.io index` + packaged `t-rec v0.8.1`.)

## After this lands

To retry the v0.9.0-preview1 publish, delete and re-push the tag (or workflow_dispatch the deploy):

```sh
git push o :refs/tags/v0.9.0-preview1
git push o v0.9.0-preview1
```

## Test plan

- [x] `cargo publish -p t-rec --dry-run --allow-dirty` packages as `v0.9.0-preview1`
- [ ] After merge + re-tagging, confirm the deploy workflow reaches `cargo publish` without the workspace-deps error and successfully uploads `0.9.0-preview1`